### PR TITLE
fix(camunda-platform): do not update empty business key

### DIFF
--- a/lib/camunda-platform/UserTaskGeneratedFormsBehavior.js
+++ b/lib/camunda-platform/UserTaskGeneratedFormsBehavior.js
@@ -56,6 +56,12 @@ export default class UserTaskFormsBehavior extends CommandInterceptor {
 
       const formData = getFormData(element);
 
+      const businessKey = formData.get('camunda:businessKey');
+
+      if (!businessKey) {
+        return;
+      }
+
       if (isBusinessKey(moddleElement, formData)) {
         modeling.updateModdleProperties(element, formData, {
           'camunda:businessKey': has(properties, 'id') ? properties.id : properties[ 'camunda:id' ]

--- a/test/camunda-platform/UserTaskGeneratedFormsBehaviorSpec.js
+++ b/test/camunda-platform/UserTaskGeneratedFormsBehaviorSpec.js
@@ -99,6 +99,27 @@ describe('camunda-platform/features/modeling - UserTaskGeneratedFormsBehavior', 
     }));
 
 
+    it('should NOT update camunda:FormData#businessKey (empty id)', inject(function(elementRegistry, modeling) {
+
+      // when
+      const element = elementRegistry.get('StartEvent_noBusinessKey');
+
+      const formData = getFormData(element),
+            formField = getFormField(element);
+
+      // assume
+      expect(formData.get('camunda:businessKey')).to.not.exist;
+
+      // when
+      modeling.updateModdleProperties(element, formField, {
+        id: 'Foo'
+      });
+
+      // then
+      expect(formData.get('camunda:businessKey')).to.not.exist;
+    }));
+
+
     it('should update camunda:FormData#businessKey (camunda:id)', inject(function(elementRegistry, modeling) {
 
       // when
@@ -114,6 +135,27 @@ describe('camunda-platform/features/modeling - UserTaskGeneratedFormsBehavior', 
 
       // then
       expect(formData.get('camunda:businessKey')).to.equal('Foo');
+    }));
+
+
+    it('should NOT update camunda:FormData#businessKey (empty camunda:id)', inject(function(elementRegistry, modeling) {
+
+      // when
+      const element = elementRegistry.get('StartEvent_noBusinessKey');
+
+      const formData = getFormData(element),
+            formField = getFormField(element);
+
+      // assume
+      expect(formData.get('camunda:businessKey')).to.not.exist;
+
+      // when
+      modeling.updateModdleProperties(element, formField, {
+        'camunda:id': 'Foo'
+      });
+
+      // then
+      expect(formData.get('camunda:businessKey')).to.not.exist;
     }));
 
   });

--- a/test/camunda-platform/camunda-user-task-generated-forms-diagram.bpmn
+++ b/test/camunda-platform/camunda-user-task-generated-forms-diagram.bpmn
@@ -21,6 +21,13 @@
         </camunda:formData>
       </bpmn:extensionElements>
     </bpmn:userTask>
+    <bpmn:startEvent id="StartEvent_noBusinessKey">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField />
+        </camunda:formData>
+      </bpmn:extensionElements>
+    </bpmn:startEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -29,6 +36,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0pn8rby_di" bpmnElement="UserTask_1">
         <dc:Bounds x="260" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nuhz87" bpmnElement="StartEvent_noBusinessKey">
+        <dc:Bounds x="152" y="192" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
Do not update empty business keys (e.g., when an empty form field id got updated).

Related to https://github.com/camunda/camunda-modeler/issues/3050