### PR TITLE
Support `bpmn:timeDate` for Timer Boundary and Intermediate Catch Events

### DIFF
--- a/lib/camunda-cloud/CleanUpTimerExpressionBehavior.js
+++ b/lib/camunda-cloud/CleanUpTimerExpressionBehavior.js
@@ -6,7 +6,7 @@ import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
 import {
   getTimerEventDefinition,
-  isTypeSupported
+  isTimerExpressionTypeSupported
 } from './util/TimerUtil';
 
 
@@ -52,7 +52,7 @@ export default class CleanUpTimerExpressionBehavior extends CommandInterceptor {
         'timeDate',
         'timeDuration'
       ].forEach((type) => {
-        if (timerEventDefinition.get(type) && !isTypeSupported(type, element)) {
+        if (timerEventDefinition.get(type) && !isTimerExpressionTypeSupported(type, element)) {
           propertiesUpdate[ type ] = undefined;
         }
       });

--- a/lib/camunda-cloud/CopyPasteBehavior.js
+++ b/lib/camunda-cloud/CopyPasteBehavior.js
@@ -72,11 +72,7 @@ export default class ZeebeModdleExtension {
       return true;
     }
 
-    if (!isTimerExpressionTypeSupported(propertyName, parent.$parent)) {
-      return false;
-    }
-
-    return true;
+    return isTimerExpressionTypeSupported(propertyName, parent.$parent);
   }
 }
 

--- a/lib/camunda-cloud/CopyPasteBehavior.js
+++ b/lib/camunda-cloud/CopyPasteBehavior.js
@@ -6,7 +6,7 @@ import {
 import { is } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
-  isTypeSupported as isTimerTypeSupported
+  isTimerExpressionTypeSupported
 } from './util/TimerUtil';
 
 const WILDCARD = '*';
@@ -72,7 +72,7 @@ export default class ZeebeModdleExtension {
       return true;
     }
 
-    if (!isTimerTypeSupported(propertyName, parent.$parent)) {
+    if (!isTimerExpressionTypeSupported(propertyName, parent.$parent)) {
       return false;
     }
 

--- a/lib/camunda-cloud/util/TimerUtil.js
+++ b/lib/camunda-cloud/util/TimerUtil.js
@@ -1,20 +1,23 @@
 import {
   getBusinessObject,
-  is
+  is,
+  isAny
 } from 'bpmn-js/lib/util/ModelUtil';
 
 
 export function getTimerEventDefinition(element) {
-  const bo = getBusinessObject(element);
+  const businessObject = getBusinessObject(element);
 
-  return bo.get('eventDefinitions').find(definition => is(definition, 'bpmn:TimerEventDefinition'));
+  return businessObject.get('eventDefinitions').find(eventDefinition => {
+    return is(eventDefinition, 'bpmn:TimerEventDefinition');
+  });
 }
 
 /**
  * Check whether a given timer expression type is supported for a given element.
  *
- * @param  {string} type
- * @param  {Element|ModdleElement} element
+ * @param {string} type
+ * @param {Element|ModdleElement} element
  *
  * @return {boolean}
  */
@@ -23,39 +26,40 @@ export function isTimerExpressionTypeSupported(type, element) {
 
   switch (type) {
   case 'timeDate':
-    if (is(element, 'bpmn:StartEvent')) {
-      return true;
-    }
-    return false;
+    return is(element, 'bpmn:StartEvent');
 
   case 'timeCycle':
-    if (is(element, 'bpmn:StartEvent') && !isInterruptingStartEvent(businessObject)) {
+    if (is(element, 'bpmn:StartEvent') && (!hasParentEventSubProcess(businessObject)) || !isInterrupting(businessObject)) {
       return true;
     }
 
-    if (is(element, 'bpmn:BoundaryEvent') && !businessObject.cancelActivity) {
+    if (is(element, 'bpmn:BoundaryEvent') && !isInterrupting(businessObject)) {
       return true;
     }
+
     return false;
 
   case 'timeDuration':
-    if (is(element, 'bpmn:IntermediateCatchEvent')) {
-      return true;
-    }
+    return isAny(element, [
+      'bpmn:BoundaryEvent',
+      'bpmn:IntermediateCatchEvent'
+    ]);
 
-    if (is(element, 'bpmn:BoundaryEvent')) {
-      return true;
-    }
+  default:
     return false;
   }
 }
 
-function isInterruptingStartEvent(bo) {
-  return isInEventSubProcess(bo) && bo.get('isInterrupting') !== false;
+function isInterrupting(businessObject) {
+  if (is(businessObject, 'bpmn:BoundaryEvent')) {
+    return businessObject.get('cancelActivity') !== false;
+  }
+
+  return businessObject.get('isInterrupting') !== false;
 }
 
-function isInEventSubProcess(bo) {
-  const parent = bo.$parent;
+function hasParentEventSubProcess(businessObject) {
+  const parent = businessObject.$parent;
 
-  return is(parent, 'bpmn:SubProcess') && parent.triggeredByEvent;
+  return parent && is(parent, 'bpmn:SubProcess') && parent.get('triggeredByEvent');
 }

--- a/lib/camunda-cloud/util/TimerUtil.js
+++ b/lib/camunda-cloud/util/TimerUtil.js
@@ -44,10 +44,18 @@ export function isTimerExpressionTypeSupported(type, element) {
     return false;
 
   case 'timeDuration':
-    return isAny(element, [
+    if (isAny(element, [
       'bpmn:BoundaryEvent',
       'bpmn:IntermediateCatchEvent'
-    ]);
+    ])) {
+      return true;
+    }
+
+    if (is(element, 'bpmn:StartEvent') && hasParentEventSubProcess(businessObject)) {
+      return true;
+    }
+
+    return false;
 
   default:
     return false;

--- a/lib/camunda-cloud/util/TimerUtil.js
+++ b/lib/camunda-cloud/util/TimerUtil.js
@@ -26,7 +26,11 @@ export function isTimerExpressionTypeSupported(type, element) {
 
   switch (type) {
   case 'timeDate':
-    return is(element, 'bpmn:StartEvent');
+    return isAny(element, [
+      'bpmn:BoundaryEvent',
+      'bpmn:IntermediateCatchEvent',
+      'bpmn:StartEvent'
+    ]);
 
   case 'timeCycle':
     if (is(element, 'bpmn:StartEvent') && (!hasParentEventSubProcess(businessObject)) || !isInterrupting(businessObject)) {

--- a/lib/camunda-cloud/util/TimerUtil.js
+++ b/lib/camunda-cloud/util/TimerUtil.js
@@ -11,17 +11,17 @@ export function getTimerEventDefinition(element) {
 }
 
 /**
- * isTypeSupported - Checks whether a given time property is supported for a given element.
+ * Check whether a given timer expression type is supported for a given element.
  *
- * @param  {string} timerDefinitionType
- * @param  {ModdleElement} element
+ * @param  {string} type
+ * @param  {Element|ModdleElement} element
  *
  * @return {boolean}
  */
-export function isTypeSupported(timerDefinitionType, element) {
+export function isTimerExpressionTypeSupported(type, element) {
   const businessObject = getBusinessObject(element);
 
-  switch (timerDefinitionType) {
+  switch (type) {
   case 'timeDate':
     if (is(element, 'bpmn:StartEvent')) {
       return true;

--- a/test/camunda-cloud/CleanUpTimerExpressionBehaviorSpec.js
+++ b/test/camunda-cloud/CleanUpTimerExpressionBehaviorSpec.js
@@ -126,10 +126,12 @@ describe('camunda-cloud/features/modeling - CleanUpTimerExpressionBehavior', fun
 
 
 
-// helper //////////////
+// helpers //////////
 
 function getTimerEventDefinition(element) {
-  const bo = getBusinessObject(element);
+  const businessObject = getBusinessObject(element);
 
-  return bo.eventDefinitions.find(def => is(def, 'bpmn:TimerEventDefinition'));
+  return businessObject.get('eventDefinitions').find(eventDefinition => {
+    return is(eventDefinition, 'bpmn:TimerEventDefinition');
+  });
 }

--- a/test/camunda-cloud/CleanUpTimerExpressionBehaviorSpec.js
+++ b/test/camunda-cloud/CleanUpTimerExpressionBehaviorSpec.js
@@ -119,7 +119,9 @@ describe('camunda-cloud/features/modeling - CleanUpTimerExpressionBehavior', fun
         expect(timerEventDefinition.get('timeCycle')).not.to.exist;
       }
     ));
+
   });
+
 });
 
 

--- a/test/camunda-cloud/CopyPasteBehaviorSpec.js
+++ b/test/camunda-cloud/CopyPasteBehaviorSpec.js
@@ -875,25 +875,6 @@ describe('CopyPasteBehavior', function() {
         expect(canCopyProperty).not.to.be.false;
       });
 
-
-      it('should NOT allow to copy-paste time date to intermediate timer catch event', function() {
-
-        // given
-        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
-              event = moddle.create('bpmn:IntermediateCatchEvent'),
-              timeDate = moddle.create('bpmn:FormalExpression', { body: '=today()' });
-
-        event.set('eventDefinitions', [ timerEventDefinition ]);
-
-        timerEventDefinition.$parent = event;
-
-        // when
-        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDate, timerEventDefinition, 'timeDate');
-
-        // then
-        expect(canCopyProperty).to.be.false;
-      });
-
     });
 
 

--- a/test/camunda-cloud/CopyPasteBehaviorSpec.js
+++ b/test/camunda-cloud/CopyPasteBehaviorSpec.js
@@ -788,146 +788,158 @@ describe('CopyPasteBehavior', function() {
 
   describe('bpmn:TimerEventDefinition', function() {
 
-    it('should allow to copy-paste time cycle within process', function() {
+    describe('timeCycle', function() {
 
-      // given
-      const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
-            startEvent = moddle.create('bpmn:StartEvent'),
-            process = moddle.create('bpmn:Process'),
-            timeCycle = moddle.create('bpmn:FormalExpression', { body: 'R/PT1H' });
+      it('should allow to copy-paste time cycle of non-interrupting timer boundary event', function() {
 
-      startEvent.$parent = process;
-      startEvent.set('eventDefinitions', [ timerEventDefinition ]);
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              boundaryEvent = moddle.create('bpmn:BoundaryEvent', { cancelActivity: false }),
+              timeCycle = moddle.create('bpmn:FormalExpression', { body: 'R/PT1H' });
 
-      timerEventDefinition.$parent = startEvent;
+        boundaryEvent.set('eventDefinitions', [ timerEventDefinition ]);
 
-      // when
-      const canCopyProperty = copyPasteBehavior.canCopyProperty(timeCycle, timerEventDefinition, 'timeCycle');
+        timerEventDefinition.$parent = boundaryEvent;
 
-      // then
-      expect(canCopyProperty).not.to.be.false;
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeCycle, timerEventDefinition, 'timeCycle');
+
+        // then
+        expect(canCopyProperty).not.to.be.false;
+      });
+
+
+      it('should NOT allow to copy-paste time cycle to interrupting timer of event subprocess', function() {
+
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              startEvent = moddle.create('bpmn:StartEvent'),
+              eventSubProcess = moddle.create('bpmn:SubProcess', { triggeredByEvent: true }),
+              timeCycle = moddle.create('bpmn:FormalExpression', { body: 'R/PT1H' });
+
+        startEvent.$parent = eventSubProcess;
+        startEvent.set('eventDefinitions', [ timerEventDefinition ]);
+
+        timerEventDefinition.$parent = startEvent;
+
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeCycle, timerEventDefinition, 'timeCycle');
+
+        // then
+        expect(canCopyProperty).to.be.false;
+      });
+
+
+      it('should allow to copy-paste time cycle within process', function() {
+
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              startEvent = moddle.create('bpmn:StartEvent'),
+              process = moddle.create('bpmn:Process'),
+              timeCycle = moddle.create('bpmn:FormalExpression', { body: 'R/PT1H' });
+
+        startEvent.$parent = process;
+        startEvent.set('eventDefinitions', [ timerEventDefinition ]);
+
+        timerEventDefinition.$parent = startEvent;
+
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeCycle, timerEventDefinition, 'timeCycle');
+
+        // then
+        expect(canCopyProperty).not.to.be.false;
+      });
+
     });
 
 
-    it('should allow to copy-paste time date within process', function() {
+    describe('timeDate', function() {
 
-      // given
-      const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
-            startEvent = moddle.create('bpmn:StartEvent'),
-            process = moddle.create('bpmn:Process'),
-            timeDate = moddle.create('bpmn:FormalExpression', { body: '=today()' });
+      it('should allow to copy-paste time date within process', function() {
 
-      startEvent.$parent = process;
-      startEvent.set('eventDefinitions', [ timerEventDefinition ]);
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              startEvent = moddle.create('bpmn:StartEvent'),
+              process = moddle.create('bpmn:Process'),
+              timeDate = moddle.create('bpmn:FormalExpression', { body: '=today()' });
 
-      timerEventDefinition.$parent = startEvent;
+        startEvent.$parent = process;
+        startEvent.set('eventDefinitions', [ timerEventDefinition ]);
 
-      // when
-      const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDate, timerEventDefinition, 'timeDate');
+        timerEventDefinition.$parent = startEvent;
 
-      // then
-      expect(canCopyProperty).not.to.be.false;
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDate, timerEventDefinition, 'timeDate');
+
+        // then
+        expect(canCopyProperty).not.to.be.false;
+      });
+
+
+      it('should NOT allow to copy-paste time date to intermediate timer catch event', function() {
+
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              event = moddle.create('bpmn:IntermediateCatchEvent'),
+              timeDate = moddle.create('bpmn:FormalExpression', { body: '=today()' });
+
+        event.set('eventDefinitions', [ timerEventDefinition ]);
+
+        timerEventDefinition.$parent = event;
+
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDate, timerEventDefinition, 'timeDate');
+
+        // then
+        expect(canCopyProperty).to.be.false;
+      });
+
     });
 
 
-    it('should allow to copy-paste time duration within process', function() {
+    describe('timeDuration', function() {
 
-      // given
-      const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
-            event = moddle.create('bpmn:IntermediateCatchEvent'),
-            process = moddle.create('bpmn:Process'),
-            timeDuration = moddle.create('bpmn:FormalExpression', { body: 'PT1H' });
+      it('should allow to copy-paste time duration within process', function() {
 
-      event.$parent = process;
-      event.set('eventDefinitions', [ timerEventDefinition ]);
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              event = moddle.create('bpmn:IntermediateCatchEvent'),
+              process = moddle.create('bpmn:Process'),
+              timeDuration = moddle.create('bpmn:FormalExpression', { body: 'PT1H' });
 
-      timerEventDefinition.$parent = event;
+        event.$parent = process;
+        event.set('eventDefinitions', [ timerEventDefinition ]);
 
-      // when
-      const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDuration, timerEventDefinition, 'timeDuration');
+        timerEventDefinition.$parent = event;
 
-      // then
-      expect(canCopyProperty).not.to.be.false;
-    });
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDuration, timerEventDefinition, 'timeDuration');
 
-
-    it('should allow to copy-paste time cycle of non-interrupting timer boundary event', function() {
-
-      // given
-      const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
-            boundaryEvent = moddle.create('bpmn:BoundaryEvent', { cancelActivity: false }),
-            timeCycle = moddle.create('bpmn:FormalExpression', { body: 'R/PT1H' });
-
-      boundaryEvent.set('eventDefinitions', [ timerEventDefinition ]);
-
-      timerEventDefinition.$parent = boundaryEvent;
-
-      // when
-      const canCopyProperty = copyPasteBehavior.canCopyProperty(timeCycle, timerEventDefinition, 'timeCycle');
-
-      // then
-      expect(canCopyProperty).not.to.be.false;
-    });
+        // then
+        expect(canCopyProperty).not.to.be.false;
+      });
 
 
-    it('should NOT allow to copy-paste time cycle to interrupting timer of event subprocess', function() {
+      it('should NOT allow to copy-paste time duration to non-interrupting timer of event subprocess', function() {
 
-      // given
-      const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
-            startEvent = moddle.create('bpmn:StartEvent'),
-            eventSubProcess = moddle.create('bpmn:SubProcess', { triggeredByEvent: true }),
-            timeCycle = moddle.create('bpmn:FormalExpression', { body: 'R/PT1H' });
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              startEvent = moddle.create('bpmn:StartEvent', { isInterrupting: false }),
+              eventSubProcess = moddle.create('bpmn:SubProcess', { triggeredByEvent: true }),
+              timeDuration = moddle.create('bpmn:FormalExpression', { body: 'PT1H' });
 
-      startEvent.$parent = eventSubProcess;
-      startEvent.set('eventDefinitions', [ timerEventDefinition ]);
+        startEvent.$parent = eventSubProcess;
+        startEvent.set('eventDefinitions', [ timerEventDefinition ]);
 
-      timerEventDefinition.$parent = startEvent;
+        timerEventDefinition.$parent = startEvent;
 
-      // when
-      const canCopyProperty = copyPasteBehavior.canCopyProperty(timeCycle, timerEventDefinition, 'timeCycle');
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDuration, timerEventDefinition, 'timeDuration');
 
-      // then
-      expect(canCopyProperty).to.be.false;
-    });
+        // then
+        expect(canCopyProperty).to.be.false;
+      });
 
-
-    it('should NOT allow to copy-paste time duration to non-interrupting timer of event subprocess', function() {
-
-      // given
-      const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
-            startEvent = moddle.create('bpmn:StartEvent', { isInterrupting: false }),
-            eventSubProcess = moddle.create('bpmn:SubProcess', { triggeredByEvent: true }),
-            timeDuration = moddle.create('bpmn:FormalExpression', { body: 'PT1H' });
-
-      startEvent.$parent = eventSubProcess;
-      startEvent.set('eventDefinitions', [ timerEventDefinition ]);
-
-      timerEventDefinition.$parent = startEvent;
-
-      // when
-      const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDuration, timerEventDefinition, 'timeDuration');
-
-      // then
-      expect(canCopyProperty).to.be.false;
-    });
-
-
-    it('should NOT allow to copy-paste time date to intermediate timer catch event', function() {
-
-      // given
-      const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
-            event = moddle.create('bpmn:IntermediateCatchEvent'),
-            timeDate = moddle.create('bpmn:FormalExpression', { body: '=today()' });
-
-      event.set('eventDefinitions', [ timerEventDefinition ]);
-
-      timerEventDefinition.$parent = event;
-
-      // when
-      const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDate, timerEventDefinition, 'timeDate');
-
-      // then
-      expect(canCopyProperty).to.be.false;
     });
 
   });

--- a/test/camunda-cloud/CopyPasteBehaviorSpec.js
+++ b/test/camunda-cloud/CopyPasteBehaviorSpec.js
@@ -790,7 +790,64 @@ describe('CopyPasteBehavior', function() {
 
     describe('timeCycle', function() {
 
-      it('should allow to copy-paste time cycle of non-interrupting timer boundary event', function() {
+      it('should allow to copy to non-interrupting timer boundary event', function() {
+
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              startEvent = moddle.create('bpmn:StartEvent'),
+              timeCycle = moddle.create('bpmn:FormalExpression', { body: 'R/PT1H' });
+
+        startEvent.set('eventDefinitions', [ timerEventDefinition ]);
+
+        timerEventDefinition.$parent = startEvent;
+
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeCycle, timerEventDefinition, 'timeCycle');
+
+        // then
+        expect(canCopyProperty).not.to.be.false;
+      });
+
+
+      it('should NOT allow to copy to non-interrupting timer boundary event', function() {
+
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              intermediateCatchEvent = moddle.create('bpmn:IntermediateCatchEvent'),
+              timeCycle = moddle.create('bpmn:FormalExpression', { body: 'R/PT1H' });
+
+        intermediateCatchEvent.set('eventDefinitions', [ timerEventDefinition ]);
+
+        timerEventDefinition.$parent = intermediateCatchEvent;
+
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeCycle, timerEventDefinition, 'timeCycle');
+
+        // then
+        expect(canCopyProperty).to.be.false;
+      });
+
+
+      it('should NOT allow to copy to timer boundary event', function() {
+
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              boundaryEvent = moddle.create('bpmn:BoundaryEvent'),
+              timeCycle = moddle.create('bpmn:FormalExpression', { body: 'R/PT1H' });
+
+        boundaryEvent.set('eventDefinitions', [ timerEventDefinition ]);
+
+        timerEventDefinition.$parent = boundaryEvent;
+
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeCycle, timerEventDefinition, 'timeCycle');
+
+        // then
+        expect(canCopyProperty).to.be.false;
+      });
+
+
+      it('should allow to copy to non-interrupting timer boundary event', function() {
 
         // given
         const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
@@ -809,7 +866,7 @@ describe('CopyPasteBehavior', function() {
       });
 
 
-      it('should NOT allow to copy-paste time cycle to interrupting timer of event subprocess', function() {
+      it('should NOT allow to copy to timer start event in event subprocess', function() {
 
         // given
         const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
@@ -830,15 +887,15 @@ describe('CopyPasteBehavior', function() {
       });
 
 
-      it('should allow to copy-paste time cycle within process', function() {
+      it('should allow to copy to non-interrupting timer start event in event subprocess', function() {
 
         // given
         const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
-              startEvent = moddle.create('bpmn:StartEvent'),
-              process = moddle.create('bpmn:Process'),
+              startEvent = moddle.create('bpmn:StartEvent', { isInterrupting: false }),
+              eventSubProcess = moddle.create('bpmn:SubProcess', { triggeredByEvent: true }),
               timeCycle = moddle.create('bpmn:FormalExpression', { body: 'R/PT1H' });
 
-        startEvent.$parent = process;
+        startEvent.$parent = eventSubProcess;
         startEvent.set('eventDefinitions', [ timerEventDefinition ]);
 
         timerEventDefinition.$parent = startEvent;
@@ -855,15 +912,112 @@ describe('CopyPasteBehavior', function() {
 
     describe('timeDate', function() {
 
-      it('should allow to copy-paste time date within process', function() {
+      it('should allow to copy to non-interrupting timer boundary event', function() {
 
         // given
         const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
               startEvent = moddle.create('bpmn:StartEvent'),
-              process = moddle.create('bpmn:Process'),
-              timeDate = moddle.create('bpmn:FormalExpression', { body: '=today()' });
+              timeDate = moddle.create('bpmn:FormalExpression', { body: '2019-10-01T12:00:00Z' });
 
-        startEvent.$parent = process;
+        startEvent.set('eventDefinitions', [ timerEventDefinition ]);
+
+        timerEventDefinition.$parent = startEvent;
+
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDate, timerEventDefinition, 'timeDate');
+
+        // then
+        expect(canCopyProperty).not.to.be.false;
+      });
+
+
+      it('should allow to copy to non-interrupting timer boundary event', function() {
+
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              intermediateCatchEvent = moddle.create('bpmn:IntermediateCatchEvent'),
+              timeDate = moddle.create('bpmn:FormalExpression', { body: '2019-10-01T12:00:00Z' });
+
+        intermediateCatchEvent.set('eventDefinitions', [ timerEventDefinition ]);
+
+        timerEventDefinition.$parent = intermediateCatchEvent;
+
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDate, timerEventDefinition, 'timeDate');
+
+        // then
+        expect(canCopyProperty).not.to.be.false;
+      });
+
+
+      it('should allow to copy to timer boundary event', function() {
+
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              boundaryEvent = moddle.create('bpmn:BoundaryEvent'),
+              timeDate = moddle.create('bpmn:FormalExpression', { body: '2019-10-01T12:00:00Z' });
+
+        boundaryEvent.set('eventDefinitions', [ timerEventDefinition ]);
+
+        timerEventDefinition.$parent = boundaryEvent;
+
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDate, timerEventDefinition, 'timeDate');
+
+        // then
+        expect(canCopyProperty).not.to.be.false;
+      });
+
+
+      it('should allow to copy to non-interrupting timer boundary event', function() {
+
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              boundaryEvent = moddle.create('bpmn:BoundaryEvent', { cancelActivity: false }),
+              timeDate = moddle.create('bpmn:FormalExpression', { body: '2019-10-01T12:00:00Z' });
+
+        boundaryEvent.set('eventDefinitions', [ timerEventDefinition ]);
+
+        timerEventDefinition.$parent = boundaryEvent;
+
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDate, timerEventDefinition, 'timeDate');
+
+        // then
+        expect(canCopyProperty).not.to.be.false;
+      });
+
+
+      it('should allow to copy to timer start event in event subprocess', function() {
+
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              startEvent = moddle.create('bpmn:StartEvent'),
+              eventSubProcess = moddle.create('bpmn:SubProcess', { triggeredByEvent: true }),
+              timeDate = moddle.create('bpmn:FormalExpression', { body: '2019-10-01T12:00:00Z' });
+
+        startEvent.$parent = eventSubProcess;
+        startEvent.set('eventDefinitions', [ timerEventDefinition ]);
+
+        timerEventDefinition.$parent = startEvent;
+
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDate, timerEventDefinition, 'timeDate');
+
+        // then
+        expect(canCopyProperty).not.to.be.false;
+      });
+
+
+      it('should allow to copy to non-interrupting timer start event in event subprocess', function() {
+
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              startEvent = moddle.create('bpmn:StartEvent', { isInterrupting: false }),
+              eventSubProcess = moddle.create('bpmn:SubProcess', { triggeredByEvent: true }),
+              timeDate = moddle.create('bpmn:FormalExpression', { body: '2019-10-01T12:00:00Z' });
+
+        startEvent.$parent = eventSubProcess;
         startEvent.set('eventDefinitions', [ timerEventDefinition ]);
 
         timerEventDefinition.$parent = startEvent;
@@ -880,18 +1034,35 @@ describe('CopyPasteBehavior', function() {
 
     describe('timeDuration', function() {
 
-      it('should allow to copy-paste time duration within process', function() {
+      it('should NOT allow to copy to non-interrupting timer boundary event', function() {
 
         // given
         const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
-              event = moddle.create('bpmn:IntermediateCatchEvent'),
-              process = moddle.create('bpmn:Process'),
-              timeDuration = moddle.create('bpmn:FormalExpression', { body: 'PT1H' });
+              startEvent = moddle.create('bpmn:StartEvent'),
+              timeDuration = moddle.create('bpmn:FormalExpression', { body: 'P14D' });
 
-        event.$parent = process;
-        event.set('eventDefinitions', [ timerEventDefinition ]);
+        startEvent.set('eventDefinitions', [ timerEventDefinition ]);
 
-        timerEventDefinition.$parent = event;
+        timerEventDefinition.$parent = startEvent;
+
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDuration, timerEventDefinition, 'timeDuration');
+
+        // then
+        expect(canCopyProperty).to.be.false;
+      });
+
+
+      it('should allow to copy to non-interrupting timer boundary event', function() {
+
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              intermediateCatchEvent = moddle.create('bpmn:IntermediateCatchEvent'),
+              timeDuration = moddle.create('bpmn:FormalExpression', { body: 'P14D' });
+
+        intermediateCatchEvent.set('eventDefinitions', [ timerEventDefinition ]);
+
+        timerEventDefinition.$parent = intermediateCatchEvent;
 
         // when
         const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDuration, timerEventDefinition, 'timeDuration');
@@ -901,13 +1072,72 @@ describe('CopyPasteBehavior', function() {
       });
 
 
-      it('should allow to copy-paste time duration to non-interrupting timer of event subprocess', function() {
+      it('should allow to copy to timer boundary event', function() {
+
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              boundaryEvent = moddle.create('bpmn:BoundaryEvent'),
+              timeDuration = moddle.create('bpmn:FormalExpression', { body: 'P14D' });
+
+        boundaryEvent.set('eventDefinitions', [ timerEventDefinition ]);
+
+        timerEventDefinition.$parent = boundaryEvent;
+
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDuration, timerEventDefinition, 'timeDuration');
+
+        // then
+        expect(canCopyProperty).not.to.be.false;
+      });
+
+
+      it('should allow to copy to non-interrupting timer boundary event', function() {
+
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              boundaryEvent = moddle.create('bpmn:BoundaryEvent', { cancelActivity: false }),
+              timeDuration = moddle.create('bpmn:FormalExpression', { body: 'P14D' });
+
+        boundaryEvent.set('eventDefinitions', [ timerEventDefinition ]);
+
+        timerEventDefinition.$parent = boundaryEvent;
+
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDuration, timerEventDefinition, 'timeDuration');
+
+        // then
+        expect(canCopyProperty).not.to.be.false;
+      });
+
+
+      it('should allow to copy to timer start event in event subprocess', function() {
+
+        // given
+        const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
+              startEvent = moddle.create('bpmn:StartEvent'),
+              eventSubProcess = moddle.create('bpmn:SubProcess', { triggeredByEvent: true }),
+              timeDuration = moddle.create('bpmn:FormalExpression', { body: 'P14D' });
+
+        startEvent.$parent = eventSubProcess;
+        startEvent.set('eventDefinitions', [ timerEventDefinition ]);
+
+        timerEventDefinition.$parent = startEvent;
+
+        // when
+        const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDuration, timerEventDefinition, 'timeDuration');
+
+        // then
+        expect(canCopyProperty).not.to.be.false;
+      });
+
+
+      it('should allow to copy to non-interrupting timer start event in event subprocess', function() {
 
         // given
         const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
               startEvent = moddle.create('bpmn:StartEvent', { isInterrupting: false }),
               eventSubProcess = moddle.create('bpmn:SubProcess', { triggeredByEvent: true }),
-              timeDuration = moddle.create('bpmn:FormalExpression', { body: 'PT1H' });
+              timeDuration = moddle.create('bpmn:FormalExpression', { body: 'P14D' });
 
         startEvent.$parent = eventSubProcess;
         startEvent.set('eventDefinitions', [ timerEventDefinition ]);

--- a/test/camunda-cloud/CopyPasteBehaviorSpec.js
+++ b/test/camunda-cloud/CopyPasteBehaviorSpec.js
@@ -901,7 +901,7 @@ describe('CopyPasteBehavior', function() {
       });
 
 
-      it('should NOT allow to copy-paste time duration to non-interrupting timer of event subprocess', function() {
+      it('should allow to copy-paste time duration to non-interrupting timer of event subprocess', function() {
 
         // given
         const timerEventDefinition = moddle.create('bpmn:TimerEventDefinition'),
@@ -918,7 +918,7 @@ describe('CopyPasteBehavior', function() {
         const canCopyProperty = copyPasteBehavior.canCopyProperty(timeDuration, timerEventDefinition, 'timeDuration');
 
         // then
-        expect(canCopyProperty).to.be.false;
+        expect(canCopyProperty).not.to.be.false;
       });
 
     });

--- a/test/camunda-cloud/CopyPasteBehaviorSpec.js
+++ b/test/camunda-cloud/CopyPasteBehaviorSpec.js
@@ -19,7 +19,7 @@ describe('CopyPasteBehavior', function() {
   });
 
 
-  describe('<zeebe:CalledElement>', function() {
+  describe('zeebe:CalledElement', function() {
 
     it('should allow on CallActivity', function() {
 
@@ -57,7 +57,7 @@ describe('CopyPasteBehavior', function() {
   });
 
 
-  describe('<zeebe:LoopCharacteristics>', function() {
+  describe('zeebe:LoopCharacteristics', function() {
 
     it('should allow on ServiceTask', function() {
 
@@ -169,7 +169,7 @@ describe('CopyPasteBehavior', function() {
   });
 
 
-  describe('<zeebe:Input>', function() {
+  describe('zeebe:Input', function() {
 
     it('should allow on ServiceTask', function() {
 
@@ -288,7 +288,7 @@ describe('CopyPasteBehavior', function() {
   });
 
 
-  describe('<zeebe:Output>', function() {
+  describe('zeebe:Output', function() {
 
     it('should allow on ServiceTask', function() {
 
@@ -428,7 +428,7 @@ describe('CopyPasteBehavior', function() {
   });
 
 
-  describe('<zeebe:IoMapping>', function() {
+  describe('zeebe:IoMapping', function() {
 
     it('should allow on ServiceTask', function() {
 
@@ -551,7 +551,7 @@ describe('CopyPasteBehavior', function() {
   });
 
 
-  describe('<zeebe:TaskHeaders>', function() {
+  describe('zeebe:TaskHeaders', function() {
 
     it('should allow on ServiceTask', function() {
 
@@ -691,7 +691,7 @@ describe('CopyPasteBehavior', function() {
   });
 
 
-  describe('<zeebe:TaskDefinition>', function() {
+  describe('zeebe:TaskDefinition', function() {
 
     it('should allow on ServiceTask', function() {
 
@@ -929,6 +929,7 @@ describe('CopyPasteBehavior', function() {
       // then
       expect(canCopyProperty).to.be.false;
     });
+
   });
 
 });

--- a/test/camunda-cloud/util/TimerUtil.bpmn
+++ b/test/camunda-cloud/util/TimerUtil.bpmn
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_148ykk6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.10.0">
+  <bpmn:process id="Process" isExecutable="true">
+    <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+      <bpmn:startEvent id="NonInterruptingTimerStartEvent_1" name="NonInterruptingTimerStartEvent_1" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_12hnz11" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="TimerStartEvent_2" name="TimerStartEvent_2">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1tmzr4x" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:startEvent id="TimerStartEvent_1" name="TimerStartEvent_1">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1jdd0zz" />
+    </bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="TimerIntermediateCatchEvent_1" name="TimerIntermediateCatchEvent_1">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_003tksl" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:task id="Activity_0yefou8" />
+    <bpmn:boundaryEvent id="NonInterruptingTimerBoundaryEvent_1" name="NonInterruptingTimerBoundaryEvent_1" cancelActivity="false" attachedToRef="Activity_0yefou8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1rr0otz" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="TimerBoundaryEvent_1" name="TimerBoundaryEvent_1" attachedToRef="Activity_0yefou8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1lh0hht" />
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNShape id="Event_1qm1iz0_di" bpmnElement="TimerStartEvent_1">
+        <dc:Bounds x="200" y="122" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="175" y="165" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0f4939x_di" bpmnElement="TimerIntermediateCatchEvent_1">
+        <dc:Bounds x="312" y="122" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="289" y="165" width="83" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0yefou8_di" bpmnElement="Activity_0yefou8">
+        <dc:Bounds x="410" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_00mfr14_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="580" y="40" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_08qjo26_di" bpmnElement="TimerStartEvent_2">
+        <dc:Bounds x="782" y="122" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="757" y="165" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_16avx57_di" bpmnElement="NonInterruptingTimerStartEvent_1">
+        <dc:Bounds x="672" y="122" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="648" y="165" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_06vkmfr_di" bpmnElement="TimerBoundaryEvent_1">
+        <dc:Bounds x="492" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="466" y="205" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_08bhvkv_di" bpmnElement="NonInterruptingTimerBoundaryEvent_1">
+        <dc:Bounds x="392" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="369" y="205" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/camunda-cloud/util/TimerUtilSpec.js
+++ b/test/camunda-cloud/util/TimerUtilSpec.js
@@ -1,0 +1,71 @@
+import {
+  bootstrapCamundaCloudModeler,
+  inject
+} from 'test/TestHelper';
+
+import { isTypeSupported as isTimerExpressionTypeSupported } from '../../../lib/camunda-cloud/util/TimerUtil';
+
+import diagramXML from './TimerUtil.bpmn';
+
+
+describe('camunda-cloud/util - TimerUtil', function() {
+
+  beforeEach(bootstrapCamundaCloudModeler(diagramXML));
+
+
+  expectTimerExpressionTypesSupported('timer start event', 'TimerStartEvent_1', {
+    timeCycle: true,
+    timeDate: true,
+    timeDuration: false
+  });
+
+
+  expectTimerExpressionTypesSupported('timer intermediate catch event', 'TimerIntermediateCatchEvent_1', {
+    timeCycle: false,
+    timeDate: false,
+    timeDuration: true
+  });
+
+
+  expectTimerExpressionTypesSupported('non-interrupting timer boundary event', 'NonInterruptingTimerBoundaryEvent_1', {
+    timeCycle: true,
+    timeDate: false,
+    timeDuration: true
+  });
+
+
+  expectTimerExpressionTypesSupported('timer boundary event', 'TimerBoundaryEvent_1', {
+    timeCycle: false,
+    timeDate: false,
+    timeDuration: true
+  });
+
+
+  expectTimerExpressionTypesSupported('non-interrupting timer start event (event sub-process)', 'NonInterruptingTimerStartEvent_1', {
+    timeCycle: true,
+    timeDate: true,
+    timeDuration: false
+  });
+
+
+  expectTimerExpressionTypesSupported('timer start event (event sub-process)', 'TimerStartEvent_2', {
+    timeCycle: false,
+    timeDate: true,
+    timeDuration: false
+  });
+
+});
+
+
+
+// helpers //////////
+
+function expectTimerExpressionTypesSupported(elementType, elementId, expressionTypes) {
+  it(`should support expression types for ${ elementType }`, inject(function(elementRegistry) {
+    const element = elementRegistry.get(elementId);
+
+    for (const expressionType in expressionTypes) {
+      expect(isTimerExpressionTypeSupported(expressionType, element)).to.equal(expressionTypes[ expressionType ]);
+    }
+  }));
+}

--- a/test/camunda-cloud/util/TimerUtilSpec.js
+++ b/test/camunda-cloud/util/TimerUtilSpec.js
@@ -44,14 +44,14 @@ describe('camunda-cloud/util - TimerUtil', function() {
   expectTimerExpressionTypesSupported('non-interrupting timer start event (event sub-process)', 'NonInterruptingTimerStartEvent_1', {
     timeCycle: true,
     timeDate: true,
-    timeDuration: false
+    timeDuration: true
   });
 
 
   expectTimerExpressionTypesSupported('timer start event (event sub-process)', 'TimerStartEvent_2', {
     timeCycle: false,
     timeDate: true,
-    timeDuration: false
+    timeDuration: true
   });
 
 });

--- a/test/camunda-cloud/util/TimerUtilSpec.js
+++ b/test/camunda-cloud/util/TimerUtilSpec.js
@@ -22,21 +22,21 @@ describe('camunda-cloud/util - TimerUtil', function() {
 
   expectTimerExpressionTypesSupported('timer intermediate catch event', 'TimerIntermediateCatchEvent_1', {
     timeCycle: false,
-    timeDate: false,
+    timeDate: true,
     timeDuration: true
   });
 
 
   expectTimerExpressionTypesSupported('non-interrupting timer boundary event', 'NonInterruptingTimerBoundaryEvent_1', {
     timeCycle: true,
-    timeDate: false,
+    timeDate: true,
     timeDuration: true
   });
 
 
   expectTimerExpressionTypesSupported('timer boundary event', 'TimerBoundaryEvent_1', {
     timeCycle: false,
-    timeDate: false,
+    timeDate: true,
     timeDuration: true
   });
 

--- a/test/camunda-cloud/util/TimerUtilSpec.js
+++ b/test/camunda-cloud/util/TimerUtilSpec.js
@@ -3,7 +3,7 @@ import {
   inject
 } from 'test/TestHelper';
 
-import { isTypeSupported as isTimerExpressionTypeSupported } from '../../../lib/camunda-cloud/util/TimerUtil';
+import { isTimerExpressionTypeSupported } from '../../../lib/camunda-cloud/util/TimerUtil';
 
 import diagramXML from './TimerUtil.bpmn';
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/3516