### PR TITLE
feat(cloud): remove output mappings from error end events

### DIFF
--- a/lib/camunda-cloud/CleanUpEndEventBehavior.js
+++ b/lib/camunda-cloud/CleanUpEndEventBehavior.js
@@ -1,0 +1,71 @@
+import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+import { find, without } from 'min-dash';
+
+export default class CleanUpEndEventBehavior extends CommandInterceptor {
+  constructor(eventBus, modeling) {
+    super(eventBus);
+
+    this.postExecuted('shape.replace', function(event) {
+
+      const {
+        context
+      } = event;
+
+      const {
+        newShape
+      } = context;
+
+      if (!is(newShape, 'bpmn:EndEvent') || !getErrorEventDefinition(newShape)) {
+        return;
+      }
+
+      const ioMapping = getIoMapping(newShape);
+
+      if (!ioMapping) {
+        return;
+      }
+
+      const businessObject = getBusinessObject(newShape),
+            extensionElements = businessObject.get('extensionElements'),
+            values = without(extensionElements.get('values'), ioMapping);
+
+      modeling.updateModdleProperties(newShape, extensionElements, { values });
+    });
+  }
+}
+
+CleanUpEndEventBehavior.$inject = [
+  'eventBus',
+  'modeling'
+];
+
+// helpers //////////
+
+export function getErrorEventDefinition(element) {
+  const businessObject = getBusinessObject(element);
+
+  const eventDefinitions = businessObject.get('eventDefinitions') || [];
+
+  return find(eventDefinitions, function(definition) {
+    return is(definition, 'bpmn:ErrorEventDefinition');
+  });
+}
+
+export function getIoMapping(element) {
+  const bo = getBusinessObject(element);
+
+  const extensionElements = bo.get('extensionElements');
+
+  if (!extensionElements) {
+    return null;
+  }
+
+  const values = extensionElements.get('values');
+
+  if (!values) {
+    return null;
+  }
+
+  return find(values, value => is(value, 'zeebe:IoMapping'));
+}

--- a/lib/camunda-cloud/index.js
+++ b/lib/camunda-cloud/index.js
@@ -1,4 +1,5 @@
 import CleanUpBusinessRuleTaskBehavior from './CleanUpBusinessRuleTaskBehavior';
+import CleanUpEndEventBehavior from './CleanUpEndEventBehavior';
 import CleanUpTimerExpressionBehavior from './CleanUpTimerExpressionBehavior';
 import CopyPasteBehavior from './CopyPasteBehavior';
 import CreateZeebeCallActivityBehavior from './CreateZeebeCallActivityBehavior';
@@ -11,6 +12,7 @@ import UpdatePropagateAllChildVariablesBehavior from './UpdatePropagateAllChildV
 export default {
   __init__: [
     'cleanUpBusinessRuleTaskBehavior',
+    'cleanUpEndEventBehavior',
     'cleanUpTimerExpressionBehavior',
     'copyPasteBehavior',
     'createZeebeCallActivityBehavior',
@@ -21,6 +23,7 @@ export default {
     'updatePropagateAllChildVariablesBehavior'
   ],
   cleanUpBusinessRuleTaskBehavior: [ 'type', CleanUpBusinessRuleTaskBehavior ],
+  cleanUpEndEventBehavior: [ 'type', CleanUpEndEventBehavior ],
   cleanUpTimerExpressionBehavior: [ 'type', CleanUpTimerExpressionBehavior ],
   copyPasteBehavior: [ 'type', CopyPasteBehavior ],
   createZeebeCallActivityBehavior: [ 'type', CreateZeebeCallActivityBehavior ],

--- a/test/camunda-cloud/CleanUpEndEventBehaviorSpec.js
+++ b/test/camunda-cloud/CleanUpEndEventBehaviorSpec.js
@@ -19,7 +19,7 @@ describe('camunda-cloud/features/modeling - CleanUpEndEventBehavior', function()
 
   describe('replace', function() {
 
-    it('should remove timeCycle when boundary event is replaced with an interrupting one', inject(
+    it('should remove output mappings when replacing end event with error end event', inject(
       function(elementRegistry, bpmnReplace) {
 
         // given

--- a/test/camunda-cloud/CleanUpEndEventBehaviorSpec.js
+++ b/test/camunda-cloud/CleanUpEndEventBehaviorSpec.js
@@ -1,0 +1,75 @@
+import {
+  bootstrapCamundaCloudModeler,
+  inject
+} from 'test/TestHelper';
+
+import { find } from 'min-dash';
+
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import diagramXML from './process-end-event.bpmn';
+
+
+describe('camunda-cloud/features/modeling - CleanUpEndEventBehavior', function() {
+
+  beforeEach(bootstrapCamundaCloudModeler(diagramXML));
+
+  describe('replace', function() {
+
+    it('should remove timeCycle when boundary event is replaced with an interrupting one', inject(
+      function(elementRegistry, bpmnReplace) {
+
+        // given
+        let endEvent = elementRegistry.get('EndEvent_1');
+
+        // assume
+        expect(getOutputs(endEvent)).to.have.length(1);
+
+        // when
+        bpmnReplace.replaceElement(endEvent, {
+          type: 'bpmn:EndEvent',
+          eventDefinitionType: 'bpmn:ErrorEventDefinition'
+        });
+
+        // then
+        endEvent = elementRegistry.get('EndEvent_1');
+        expect(getOutputs(endEvent)).to.have.length(0);
+      }
+    ));
+  });
+
+
+});
+
+
+// helpers //////////
+
+function getOutputs(element) {
+  const ioMapping = getIoMapping(element);
+  if (!ioMapping) {
+    return [];
+  }
+
+  return ioMapping.get('outputParameters');
+}
+
+function getIoMapping(element) {
+  const bo = getBusinessObject(element);
+
+  const extensionElements = bo.get('extensionElements');
+
+  if (!extensionElements) {
+    return null;
+  }
+
+  const values = extensionElements.get('values');
+
+  if (!values) {
+    return null;
+  }
+
+  return find(values, value => is(value, 'zeebe:IoMapping'));
+}

--- a/test/camunda-cloud/process-end-event.bpmn
+++ b/test/camunda-cloud/process-end-event.bpmn
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_09tl013" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.15.0-nightly.20230815" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+  <bpmn:process id="Process_1gjeary" isExecutable="true">
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="" target="OutputVariable_04kmfu5" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1gjeary">
+      <bpmndi:BPMNShape id="Event_1mzj94q_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="152" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
related to camunda/camunda-modeler#3782

ensures that the hidden group from https://github.com/bpmn-io/bpmn-js-properties-panel/pull/952 is also removed from the XML