### PR TITLE
Support Linked Camunda Form

### DIFF
--- a/lib/camunda-cloud/FormsBehavior.js
+++ b/lib/camunda-cloud/FormsBehavior.js
@@ -1,4 +1,3 @@
-
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
 import { createElement } from '../util/ElementUtil';
@@ -9,19 +8,18 @@ import {
 } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
-  createFormDefinition,
-  createFormId,
-  createFormKey,
-  createUserTaskForm,
+  createUserTaskFormId,
   getFormDefinition,
-  getUserTaskForm
+  getRootElement,
+  getUserTaskForm,
+  userTaskFormIdToFormKey
 } from './util/FormsUtil';
 
 
 /**
- * Zeebe BPMN specific form definition behavior.
+ * Zeebe BPMN specific forms behavior.
  */
-export default class FormDefinitionBehavior extends CommandInterceptor {
+export default class FormsBehavior extends CommandInterceptor {
   constructor(bpmnFactory, eventBus, modeling) {
     super(eventBus);
 
@@ -36,7 +34,7 @@ export default class FormDefinitionBehavior extends CommandInterceptor {
 
       const rootElement = getRootElement(oldParent);
 
-      const userTaskForm = getUserTaskForm(shape, rootElement);
+      const userTaskForm = getUserTaskForm(shape, { rootElement });
 
       if (!is(shape, 'bpmn:UserTask') || !userTaskForm) {
         return;
@@ -87,9 +85,11 @@ export default class FormDefinitionBehavior extends CommandInterceptor {
       });
 
       // (3) create new form definition
-      const formId = createFormId();
+      const userTaskFormId = createUserTaskFormId();
 
-      const newFormDefinition = createFormDefinition({ formKey: createFormKey(formId) }, extensionElements, bpmnFactory);
+      const newFormDefinition = createElement('zeebe:FormDefinition', {
+        formKey: userTaskFormIdToFormKey(userTaskFormId)
+      }, extensionElements, bpmnFactory);
 
       values = [
         ...values,
@@ -101,8 +101,8 @@ export default class FormDefinitionBehavior extends CommandInterceptor {
       });
 
       // (4) create new user task form
-      const userTaskForm = createUserTaskForm({
-        id: formId,
+      const userTaskForm = createElement('zeebe:UserTaskForm', {
+        id: userTaskFormId,
         body: oldUserTaskForm ? oldUserTaskForm.get('body') : ''
       }, rootExtensionElements, bpmnFactory);
 
@@ -117,22 +117,8 @@ export default class FormDefinitionBehavior extends CommandInterceptor {
   }
 }
 
-FormDefinitionBehavior.$inject = [
+FormsBehavior.$inject = [
   'bpmnFactory',
   'eventBus',
   'modeling'
 ];
-
-
-// helpers //////////////
-
-function getRootElement(element) {
-  var businessObject = getBusinessObject(element),
-      parent = businessObject;
-
-  while (parent.$parent && !is(parent, 'bpmn:Process')) {
-    parent = parent.$parent;
-  }
-
-  return parent;
-}

--- a/lib/camunda-cloud/FormsBehavior.js
+++ b/lib/camunda-cloud/FormsBehavior.js
@@ -1,3 +1,5 @@
+import { without } from 'min-dash';
+
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
 import { createElement } from '../util/ElementUtil';
@@ -12,6 +14,7 @@ import {
   getFormDefinition,
   getRootElement,
   getUserTaskForm,
+  isUserTaskFormKey,
   userTaskFormIdToFormKey
 } from './util/FormsUtil';
 
@@ -22,6 +25,22 @@ import {
 export default class FormsBehavior extends CommandInterceptor {
   constructor(bpmnFactory, eventBus, modeling) {
     super(eventBus);
+
+    function removeUserTaskForm(element, moddleElement, userTaskForm) {
+      const extensionElements = moddleElement.get('extensionElements');
+
+      const values = without(extensionElements.get('values'), userTaskForm);
+
+      modeling.updateModdleProperties(element, extensionElements, {
+        values
+      });
+
+      if (!values.length) {
+        modeling.updateModdleProperties(element, moddleElement, {
+          extensionElements: undefined
+        });
+      }
+    }
 
     /**
      * Remove zeebe:UserTaskForm on user task removed.
@@ -40,13 +59,7 @@ export default class FormsBehavior extends CommandInterceptor {
         return;
       }
 
-      const rootExtensionElements = rootElement.get('extensionElements');
-
-      const values = rootExtensionElements.get('values').filter((element) => {
-        return element !== userTaskForm;
-      });
-
-      modeling.updateModdleProperties(shape, rootExtensionElements, { values });
+      removeUserTaskForm(shape, rootElement, userTaskForm);
     }, true);
 
 
@@ -114,6 +127,67 @@ export default class FormsBehavior extends CommandInterceptor {
       });
     }, true);
 
+
+    /**
+     * Ensure that a user task only has one of the following:
+     *
+     * 1. zeebe:FormDefinition with zeebe:formId (linked Camunda form)
+     * 2. zeebe:FormDefinition with zeebe:formKey in the format of camunda-forms:bpmn:UserTaskForm_1 (embedded Camunda form)
+     * 3. zeebe:FormDefinition with zeebe:formKey (custom form)
+     */
+    this.preExecute('element.updateModdleProperties', function(context) {
+      const {
+        moddleElement,
+        properties
+      } = context;
+
+      if (is(moddleElement, 'zeebe:FormDefinition')) {
+        if ('formId' in properties) {
+          properties.formKey = undefined;
+        } else if ('formKey' in properties) {
+          properties.formId = undefined;
+        }
+      }
+    }, true);
+
+    /**
+     * Clean up user task form after form key or definition is removed. Clean up
+     * empty extension elements after form definition is removed.
+     */
+    this.postExecute('element.updateModdleProperties', function(context) {
+      const {
+        element,
+        moddleElement,
+        oldProperties
+      } = context;
+
+      if (is(moddleElement, 'zeebe:FormDefinition')) {
+        const formKey = moddleElement.get('formKey');
+
+        if (!formKey || !isUserTaskFormKey(formKey)) {
+          const userTaskForm = getUserTaskForm(element, { formKey: oldProperties.formKey });
+
+          if (userTaskForm) {
+            removeUserTaskForm(element, getRootElement(element), userTaskForm);
+          }
+        }
+      } else if (isExtensionElementRemoved(context, 'zeebe:FormDefinition')) {
+        const formDefinition = oldProperties.values.find(value => is(value, 'zeebe:FormDefinition'));
+
+        const userTaskForm = getUserTaskForm(element, { formKey: formDefinition.get('formKey') });
+
+        if (userTaskForm) {
+          removeUserTaskForm(element, getRootElement(element), userTaskForm);
+        }
+
+        if (!moddleElement.get('values').length) {
+          modeling.updateProperties(element, {
+            extensionElements: undefined
+          });
+        }
+      }
+    }, true);
+
   }
 }
 
@@ -122,3 +196,17 @@ FormsBehavior.$inject = [
   'eventBus',
   'modeling'
 ];
+
+function isExtensionElementRemoved(context, type) {
+  const {
+    moddleElement,
+    oldProperties,
+    properties
+  } = context;
+
+  return is(moddleElement, 'bpmn:ExtensionElements')
+    && 'values' in oldProperties
+    && 'values' in properties
+    && oldProperties.values.find(value => is(value, type))
+    && !properties.values.find(value => is(value, type));
+}

--- a/lib/camunda-cloud/index.js
+++ b/lib/camunda-cloud/index.js
@@ -4,7 +4,7 @@ import CleanUpTimerExpressionBehavior from './CleanUpTimerExpressionBehavior';
 import CopyPasteBehavior from './CopyPasteBehavior';
 import CreateZeebeCallActivityBehavior from './CreateZeebeCallActivityBehavior';
 import DeleteParticipantBehaviour from '../shared/DeleteParticipantBehaviour';
-import FormDefinitionBehavior from './FormDefinitionBehavior';
+import FormsBehavior from './FormsBehavior';
 import RemoveAssignmentDefinitionBehavior from './RemoveAssignmentDefinitionBehavior';
 import RemoveTaskScheduleBehavior from './RemoveTaskScheduleBehavior';
 import UpdatePropagateAllChildVariablesBehavior from './UpdatePropagateAllChildVariablesBehavior';
@@ -17,7 +17,7 @@ export default {
     'copyPasteBehavior',
     'createZeebeCallActivityBehavior',
     'deleteParticipantBehaviour',
-    'formDefinitionBehavior',
+    'formsBehavior',
     'removeAssignmentDefinitionBehavior',
     'removeTaskScheduleBehavior',
     'updatePropagateAllChildVariablesBehavior'
@@ -28,7 +28,7 @@ export default {
   copyPasteBehavior: [ 'type', CopyPasteBehavior ],
   createZeebeCallActivityBehavior: [ 'type', CreateZeebeCallActivityBehavior ],
   deleteParticipantBehaviour: [ 'type', DeleteParticipantBehaviour ],
-  formDefinitionBehavior: [ 'type', FormDefinitionBehavior ],
+  formsBehavior: [ 'type', FormsBehavior ],
   removeAssignmentDefinitionBehavior: [ 'type', RemoveAssignmentDefinitionBehavior ],
   removeTaskScheduleBehavior: [ 'type', RemoveTaskScheduleBehavior ],
   updatePropagateAllChildVariablesBehavior: [ 'type', UpdatePropagateAllChildVariablesBehavior ]

--- a/lib/camunda-cloud/util/FormsUtil.js
+++ b/lib/camunda-cloud/util/FormsUtil.js
@@ -1,7 +1,3 @@
-import { getExtensionElementsList } from '../../util/ExtensionElementsUtil';
-
-import { createElement } from '../../util/ElementUtil';
-
 import {
   getBusinessObject,
   is
@@ -9,46 +5,10 @@ import {
 
 import { getPrefixedId } from '../../util/IdsUtil';
 
-import { find } from 'min-dash';
+import { getExtensionElementsList } from '../../util/ExtensionElementsUtil';
 
-const USER_TASK_FORM_PREFIX = 'UserTaskForm_';
-
-
-export function createFormDefinition(properties, extensionElements, bpmnFactory) {
-  return createElement(
-    'zeebe:FormDefinition',
-    properties,
-    extensionElements,
-    bpmnFactory
-  );
-}
-
-export function createFormId() {
-  return getPrefixedId(USER_TASK_FORM_PREFIX);
-}
-
-export function createFormKey(formId) {
-  return `camunda-forms:bpmn:${ formId }`;
-}
-
-export function createUserTaskForm(properties, extensionElements, bpmnFactory) {
-  return createElement(
-    'zeebe:UserTaskForm',
-    properties,
-    extensionElements,
-    bpmnFactory
-  );
-}
-
-function findUserTaskForm(formKey, rootElement) {
-  const userTaskForms = getExtensionElementsList(rootElement, 'zeebe:UserTaskForm');
-
-  return find(userTaskForms, (userTaskForm) => {
-    const id = userTaskForm.get('zeebe:id');
-
-    return createFormKey(id) === formKey;
-  });
-}
+const FORM_KEY_PREFIX = 'camunda-forms:bpmn:',
+      USER_TASK_FORM_ID_PREFIX = 'UserTaskForm_';
 
 export function getFormDefinition(element) {
   const businessObject = getBusinessObject(element);
@@ -58,27 +18,55 @@ export function getFormDefinition(element) {
   return formDefinitions[ 0 ];
 }
 
-function getRootElement(element) {
-  var businessObject = getBusinessObject(element),
-      parent = businessObject;
+export function getUserTaskForm(element, options = {}) {
+  let {
+    formKey,
+    rootElement
+  } = options;
+
+  rootElement = rootElement || getRootElement(element);
+
+  if (!formKey) {
+    const formDefinition = getFormDefinition(element);
+
+    if (!formDefinition) {
+      return;
+    }
+
+    formKey = formDefinition.get('formKey');
+  }
+
+  const userTaskForms = getExtensionElementsList(rootElement, 'zeebe:UserTaskForm');
+
+  return userTaskForms.find(userTaskForm => {
+    return userTaskFormIdToFormKey(userTaskForm.get('id')) === formKey;
+  });
+}
+
+export function userTaskFormIdToFormKey(userTaskFormId) {
+  return `${ FORM_KEY_PREFIX }${ userTaskFormId }`;
+}
+
+export function formKeyToUserTaskFormId(formKey) {
+  return formKey.replace(FORM_KEY_PREFIX, '');
+}
+
+export function isUserTaskFormKey(formKey) {
+  return formKey && formKey.startsWith(FORM_KEY_PREFIX);
+}
+
+export function createUserTaskFormId() {
+  return getPrefixedId(USER_TASK_FORM_ID_PREFIX);
+}
+
+export function getRootElement(element) {
+  const businessObject = getBusinessObject(element);
+
+  let parent = businessObject;
 
   while (parent.$parent && !is(parent, 'bpmn:Process')) {
     parent = parent.$parent;
   }
 
   return parent;
-}
-
-export function getUserTaskForm(element, parent) {
-  const rootElement = parent || getRootElement(element);
-
-  const formDefinition = getFormDefinition(element);
-
-  if (!formDefinition) {
-    return;
-  }
-
-  const formKey = formDefinition.get('zeebe:formKey');
-
-  return findUserTaskForm(formKey, rootElement);
 }

--- a/test/camunda-cloud/FormDefinitionBehaviorSpec.js
+++ b/test/camunda-cloud/FormDefinitionBehaviorSpec.js
@@ -1,3 +1,5 @@
+import { without } from 'min-dash';
+
 import {
   bootstrapCamundaCloudModeler,
   inject
@@ -20,7 +22,7 @@ describe('camunda-cloud/features/modeling - FormsBehavior', function() {
   beforeEach(bootstrapCamundaCloudModeler(diagramXML));
 
 
-  describe('cleanup user task forms', function() {
+  describe('remove user task form', function() {
 
     describe('on remove user task', function() {
 
@@ -147,10 +149,28 @@ describe('camunda-cloud/features/modeling - FormsBehavior', function() {
 
     });
 
+
+    it('should remove extension elements', inject(function(canvas, elementRegistry, modeling) {
+
+      // given
+      const rootElement = canvas.getRootElement();
+
+      const userTask1 = elementRegistry.get('UserTask_1'),
+            userTask2 = elementRegistry.get('UserTask_2');
+
+      // when
+      modeling.removeElements([ userTask1, userTask2 ]);
+
+      // then
+      const extensionElements = getBusinessObject(rootElement).get('extensionElements');
+
+      expect(extensionElements).not.to.exist;
+    }));
+
   });
 
 
-  describe('create new user task form', function() {
+  describe('create user task form', function() {
 
     describe('on copy user task', function() {
 
@@ -241,6 +261,190 @@ describe('camunda-cloud/features/modeling - FormsBehavior', function() {
 
         // then
         expect(userTaskForms).to.have.length(3);
+      }));
+
+    });
+
+  });
+
+
+  describe('update form definition', function() {
+
+    describe('set form ID', function() {
+
+      it('should remove custom form key', inject(function(elementRegistry, modeling) {
+
+        // given
+        const userTask = elementRegistry.get('UserTask_11');
+
+        const formDefinition = getFormDefinition(userTask);
+
+        // when
+        modeling.updateModdleProperties(userTask, formDefinition, {
+          formId: 'foobar'
+        });
+
+        // then
+        expect(formDefinition.get('formKey')).not.to.exist;
+      }));
+
+
+      it('should remove user task form', inject(function(canvas, elementRegistry, modeling) {
+
+        // given
+        const userTask = elementRegistry.get('UserTask_1');
+
+        const formDefinition = getFormDefinition(userTask);
+
+        // when
+        modeling.updateModdleProperties(userTask, formDefinition, {
+          formId: 'foobar'
+        });
+
+        // then
+        expect(formDefinition.get('formKey')).not.to.exist;
+
+        const rootElement = canvas.getRootElement();
+
+        const userTaskForms = getUserTaskForms(rootElement);
+
+        expect(hasUsertaskForm('UserTaskForm_1', userTaskForms)).to.be.false;
+      }));
+
+
+      it('should remove extension elements', inject(function(canvas, elementRegistry, modeling) {
+
+        // given
+        const userTask1 = elementRegistry.get('UserTask_1'),
+              userTask2 = elementRegistry.get('UserTask_2');
+
+        modeling.removeElements([ userTask2 ]);
+
+        const formDefinition = getFormDefinition(userTask1);
+
+        // when
+        modeling.updateModdleProperties(userTask1, formDefinition, {
+          formId: 'foobar'
+        });
+
+        // then
+        expect(formDefinition.get('formKey')).not.to.exist;
+
+        const rootElement = canvas.getRootElement();
+
+        const extensionElements = getBusinessObject(rootElement).get('extensionElements');
+
+        expect(extensionElements).not.to.exist;
+      }));
+
+    });
+
+
+    describe('set form key', function() {
+
+      it('should remove form ID', inject(function(elementRegistry, modeling) {
+
+        // given
+        const userTask = elementRegistry.get('UserTask_12');
+
+        const formDefinition = getFormDefinition(userTask);
+
+        // when
+        modeling.updateModdleProperties(userTask, formDefinition, {
+          formKey: 'foobar'
+        });
+
+        // then
+        expect(formDefinition.get('formId')).not.to.exist;
+      }));
+
+
+      it('should remove user task form', inject(function(canvas, elementRegistry, modeling) {
+
+        // given
+        const userTask = elementRegistry.get('UserTask_1');
+
+        const formDefinition = getFormDefinition(userTask);
+
+        // when
+        modeling.updateModdleProperties(userTask, formDefinition, {
+          formKey: 'foobar'
+        });
+
+        // then
+        const rootElement = canvas.getRootElement();
+
+        const userTaskForms = getUserTaskForms(rootElement);
+
+        expect(hasUsertaskForm('UserTaskForm_1', userTaskForms)).to.be.false;
+      }));
+
+
+      it('should remove extension elements', inject(function(canvas, elementRegistry, modeling) {
+
+        // given
+        const userTask1 = elementRegistry.get('UserTask_1'),
+              userTask2 = elementRegistry.get('UserTask_2');
+
+        modeling.removeElements([ userTask2 ]);
+
+        const formDefinition = getFormDefinition(userTask1);
+
+        // when
+        modeling.updateModdleProperties(userTask1, formDefinition, {
+          formKey: 'foobar'
+        });
+
+        // then
+        const rootElement = canvas.getRootElement();
+
+        const extensionElements = getBusinessObject(rootElement).get('extensionElements');
+
+        expect(extensionElements).not.to.exist;
+      }));
+
+    });
+
+
+    describe('remove form definition', function() {
+
+      it('should remove user task form', inject(function(canvas, elementRegistry, modeling) {
+
+        // given
+        const userTask = elementRegistry.get('UserTask_1'),
+              extensionElements = getBusinessObject(userTask).get('extensionElements');
+
+        const formDefinition = getFormDefinition(userTask);
+
+        // when
+        modeling.updateModdleProperties(userTask, extensionElements, {
+          values: without(extensionElements.get('values'), formDefinition)
+        });
+
+        // then
+        const rootElement = canvas.getRootElement();
+
+        const userTaskForms = getUserTaskForms(rootElement);
+
+        expect(hasUsertaskForm('UserTaskForm_1', userTaskForms)).to.be.false;
+      }));
+
+
+      it('should remove extension elements', inject(function(elementRegistry, modeling) {
+
+        // given
+        const userTask = elementRegistry.get('UserTask_1'),
+              extensionElements = getBusinessObject(userTask).get('extensionElements');
+
+        const formDefinition = getFormDefinition(userTask);
+
+        // when
+        modeling.updateModdleProperties(userTask, extensionElements, {
+          values: without(extensionElements.get('values'), formDefinition)
+        });
+
+        // then
+        expect(getBusinessObject(userTask).get('extensionElements')).not.to.exist;
       }));
 
     });

--- a/test/camunda-cloud/FormDefinitionBehaviorSpec.js
+++ b/test/camunda-cloud/FormDefinitionBehaviorSpec.js
@@ -15,7 +15,7 @@ import {
 import diagramXML from './process-user-tasks.bpmn';
 
 
-describe('camunda-cloud/features/modeling - FormDefinitionBehavior', function() {
+describe('camunda-cloud/features/modeling - FormsBehavior', function() {
 
   beforeEach(bootstrapCamundaCloudModeler(diagramXML));
 

--- a/test/camunda-cloud/process-user-tasks.bpmn
+++ b/test/camunda-cloud/process-user-tasks.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1mcvv1o" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.8.0-rc.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1mcvv1o" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.15.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:extensionElements>
       <zeebe:userTaskForm id="UserTaskForm_1">{ components: [ { label: "field", key: "field" } ] }</zeebe:userTaskForm>
@@ -58,6 +58,16 @@
         <zeebe:taskSchedule followUpDate="=followUpDate" />
       </bpmn:extensionElements>
     </bpmn:userTask>
+    <bpmn:userTask id="UserTask_11" name="UserTask_11">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="foobar" />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+    <bpmn:userTask id="UserTask_12" name="UserTask_12">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="foobar" />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
     <bpmn:group id="Group_1iij674" categoryValueRef="CategoryValue_1ls7csf" />
     <bpmn:group id="Group_03ciaww" categoryValueRef="CategoryValue_1e18h7j" />
     <bpmn:group id="Group_0pfvk8p" categoryValueRef="CategoryValue_1efmoxk" />
@@ -106,8 +116,15 @@
       <bpmndi:BPMNShape id="Activity_0jt9scz_di" bpmnElement="UserTask_10">
         <dc:Bounds x="990" y="150" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0db7jhq_di" bpmnElement="UserTask_11">
+        <dc:Bounds x="190" y="330" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1gtn2y5_di" bpmnElement="UserTask_12">
+        <dc:Bounds x="190" y="420" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Group_1iij674_di" bpmnElement="Group_1iij674">
-        <dc:Bounds x="160" y="80" width="160" height="300" />
+        <dc:Bounds x="160" y="80" width="160" height="480" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="203" y="87" width="75" height="14" />
         </bpmndi:BPMNLabel>


### PR DESCRIPTION
* clean up form definition when updating form key or ID
* clean up user task form when updating form reference
* clean up empty extension elements

---

Related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/949