### PR TITLE
Support zeebe:ExecutionListener

### DIFF
--- a/lib/camunda-cloud/CleanUpExecutionListenersBehavior.js
+++ b/lib/camunda-cloud/CleanUpExecutionListenersBehavior.js
@@ -1,0 +1,117 @@
+import { getBusinessObject, is, isAny } from 'bpmn-js/lib/util/ModelUtil';
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+import { find, without } from 'min-dash';
+
+import { getExtensionElementsList } from '../util/ExtensionElementsUtil';
+
+const DISALLOWED_START_LISTENER_TYPES = [
+  'bpmn:StartEvent',
+  'bpmn:BoundaryEvent'
+];
+
+export default class CleanUpExecutionListenersBehavior extends CommandInterceptor {
+  constructor(eventBus, modeling) {
+    super(eventBus);
+
+    // remove execution listeners of disallowed type
+    this.postExecuted('shape.replace', function(event) {
+      const element = event.context.newShape;
+
+      const executionListenersContainer = getExecutionListenersContainer(element);
+      if (!executionListenersContainer) {
+        return;
+      }
+
+      const listeners = executionListenersContainer.get('listeners');
+      const newListeners = withoutDisallowedListeners(element, listeners);
+
+      if (newListeners.length !== listeners.length) {
+        modeling.updateModdleProperties(element, executionListenersContainer, { listeners: newListeners });
+      }
+    });
+
+    // remove empty execution listener container
+    this.postExecuted('element.updateModdleProperties', function(event) {
+      const {
+        element,
+        moddleElement
+      } = event.context;
+
+      if (!is(moddleElement, 'zeebe:ExecutionListeners')) {
+        return;
+      }
+
+      const listeners = moddleElement.get('listeners');
+      if (listeners.length) {
+        return;
+      }
+
+      const extensionElements = moddleElement.$parent;
+      modeling.updateModdleProperties(element, extensionElements, { values: without(extensionElements.get('values'), moddleElement) });
+    });
+  }
+}
+
+CleanUpExecutionListenersBehavior.$inject = [
+  'eventBus',
+  'modeling'
+];
+
+// helpers //////////
+function withoutDisallowedListeners(element, listeners) {
+  listeners = withoutDisallowedStartListeners(element, listeners);
+  listeners = withoutDisallowedEndListeners(element, listeners);
+
+  return listeners;
+}
+
+function withoutDisallowedStartListeners(element, listeners) {
+  if (isAny(element, DISALLOWED_START_LISTENER_TYPES)) {
+    return listeners.filter(listener => listener.eventType !== 'start');
+  }
+
+  return listeners;
+}
+
+function withoutDisallowedEndListeners(element, listeners) {
+  if (shouldRemoveEndListeners(element)) {
+    return listeners.filter(listener => listener.eventType !== 'end');
+  }
+
+  return listeners;
+}
+
+function shouldRemoveEndListeners(element) {
+  if (
+    is(element, 'bpmn:BoundaryEvent') && isCompensationEvent(element) ||
+    is(element, 'bpmn:EndEvent') && isErrorEvent(element) ||
+    is(element, 'bpmn:Gateway')
+  ) {
+    return true;
+  }
+}
+
+function isCompensationEvent(element) {
+  const eventDefinitions = getEventDefinitions(element);
+
+  return find(eventDefinitions, function(definition) {
+    return is(definition, 'bpmn:CompensateEventDefinition');
+  });
+}
+
+function isErrorEvent(element) {
+  const eventDefinitions = getEventDefinitions(element);
+
+  return find(eventDefinitions, function(definition) {
+    return is(definition, 'bpmn:ErrorEventDefinition');
+  });
+}
+
+function getEventDefinitions(element) {
+  const businessObject = getBusinessObject(element);
+  return businessObject.get('eventDefinitions') || [];
+}
+
+function getExecutionListenersContainer(element) {
+  return getExtensionElementsList(element, 'zeebe:ExecutionListeners')[0];
+}

--- a/lib/camunda-cloud/index.js
+++ b/lib/camunda-cloud/index.js
@@ -1,5 +1,6 @@
 import CleanUpBusinessRuleTaskBehavior from './CleanUpBusinessRuleTaskBehavior';
 import CleanUpEndEventBehavior from './CleanUpEndEventBehavior';
+import CleanUpExecutionListenersBehavior from './CleanUpExecutionListenersBehavior';
 import CleanUpSubscriptionBehavior from './CleanUpSubscriptionBehavior';
 import CleanUpTimerExpressionBehavior from './CleanUpTimerExpressionBehavior';
 import CopyPasteBehavior from './CopyPasteBehavior';
@@ -13,6 +14,7 @@ export default {
   __init__: [
     'cleanUpBusinessRuleTaskBehavior',
     'cleanUpEndEventBehavior',
+    'cleanUpExecutionListenersBehavior',
     'cleanUpSubscriptionBehavior',
     'cleanUpTimerExpressionBehavior',
     'copyPasteBehavior',
@@ -24,6 +26,7 @@ export default {
   ],
   cleanUpBusinessRuleTaskBehavior: [ 'type', CleanUpBusinessRuleTaskBehavior ],
   cleanUpEndEventBehavior: [ 'type', CleanUpEndEventBehavior ],
+  cleanUpExecutionListenersBehavior: [ 'type', CleanUpExecutionListenersBehavior ],
   cleanUpSubscriptionBehavior: [ 'type', CleanUpSubscriptionBehavior ],
   cleanUpTimerExpressionBehavior: [ 'type', CleanUpTimerExpressionBehavior ],
   copyPasteBehavior: [ 'type', CopyPasteBehavior ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "sinon": "^17.0.1",
         "sinon-chai": "^3.7.0",
         "webpack": "^5.74.0",
-        "zeebe-bpmn-moddle": "^1.1.0"
+        "zeebe-bpmn-moddle": "^1.2.0"
       },
       "peerDependencies": {
         "bpmn-js": ">= 9",
@@ -7123,10 +7123,11 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.1.0.tgz",
-      "integrity": "sha512-ES/UZFO0VmKvAzL4+cD3VcQpKvlmgLtnFKTyiv0DdDcxNrdQg1rI0OmUdrKMiybAbtAgPDkVXZCusE3kkXwEyQ==",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.2.0.tgz",
+      "integrity": "sha512-KtY9CYs2qYKQMV7xdLY7Oj7Mgb0fA13DD8T0bYwv3JOkdqfW4IIqm+aMD+vvZ4j+2iaCGaqEA6XKHS5sZKG3Fg==",
+      "dev": true,
+      "license": "MIT"
     }
   },
   "dependencies": {
@@ -12423,9 +12424,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.1.0.tgz",
-      "integrity": "sha512-ES/UZFO0VmKvAzL4+cD3VcQpKvlmgLtnFKTyiv0DdDcxNrdQg1rI0OmUdrKMiybAbtAgPDkVXZCusE3kkXwEyQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.2.0.tgz",
+      "integrity": "sha512-KtY9CYs2qYKQMV7xdLY7Oj7Mgb0fA13DD8T0bYwv3JOkdqfW4IIqm+aMD+vvZ4j+2iaCGaqEA6XKHS5sZKG3Fg==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "webpack": "^5.74.0",
-    "zeebe-bpmn-moddle": "^1.1.0"
+    "zeebe-bpmn-moddle": "^1.2.0"
   },
   "peerDependencies": {
     "bpmn-js": ">= 9",

--- a/test/camunda-cloud/CleanUpExecutionListenersBehaviorSpec.js
+++ b/test/camunda-cloud/CleanUpExecutionListenersBehaviorSpec.js
@@ -1,0 +1,212 @@
+import {
+  bootstrapCamundaCloudModeler,
+  inject
+} from 'test/TestHelper';
+
+import { getExtensionElementsList } from 'lib/util/ExtensionElementsUtil';
+
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import diagramXML from './execution-listeners.bpmn';
+
+
+describe('camunda-cloud/features/modeling - CleanUpExecutionListenersBehavior', function() {
+
+  beforeEach(bootstrapCamundaCloudModeler(diagramXML));
+
+
+  it('should keep valid execution listeners', inject(function(bpmnReplace, elementRegistry) {
+
+    // given
+    const el = elementRegistry.get('Gateway');
+
+    // when
+    const result = bpmnReplace.replaceElement(el, {
+      type: 'bpmn:InclusiveGateway'
+    });
+
+    // then
+    const container = getExtensionElementsList(getBusinessObject(result), 'zeebe:ExecutionListeners')[0];
+
+    expect(container.get('listeners')).to.have.lengthOf(2);
+  }));
+
+
+  describe('remove execution listeners if disallowed in element type', function() {
+
+    const testCases = [
+      {
+        title: 'Timer Boundary Event -> Compensation Boundary Event',
+        element: 'BoundaryEvent',
+        target: {
+          type: 'bpmn:BoundaryEvent',
+          eventDefinitionType: 'bpmn:CompensateEventDefinition'
+        }
+      },
+      {
+        title: 'Timer End Event -> Error End Event',
+        element: 'TimerEndEvent',
+        target: {
+          type: 'bpmn:EndEvent',
+          eventDefinitionType: 'bpmn:ErrorEventDefinition'
+        }
+      },
+      {
+        title: 'Exclusive Gateway -> Complex Gateway',
+        element: 'Gateway',
+        target: {
+          type: 'bpmn:ComplexGateway'
+        }
+      }
+    ];
+
+    for (const { title, element, target } of testCases) {
+
+      describe(title, function() {
+
+        it('should execute', inject(function(bpmnReplace, elementRegistry) {
+
+          // given
+          let el = elementRegistry.get(element);
+
+          // when
+          bpmnReplace.replaceElement(el, target);
+
+          // then
+          el = elementRegistry.get(element);
+          const executionListenersContainer = getExecutionListenersContainer(el);
+
+          expect(executionListenersContainer).not.to.exist;
+        }));
+
+
+        it('should undo', inject(function(bpmnReplace, commandStack, elementRegistry) {
+
+          // given
+          let el = elementRegistry.get(element);
+
+          // when
+          bpmnReplace.replaceElement(el, target);
+
+          commandStack.undo();
+
+          // then
+          el = elementRegistry.get(element);
+          const extensionElements = getBusinessObject(el).get('extensionElements');
+
+          expect(extensionElements.get('values')).to.have.lengthOf(1);
+        }));
+
+
+        it('should redo', inject(function(bpmnReplace, commandStack, elementRegistry) {
+
+          // given
+          let el = elementRegistry.get(element);
+
+          // when
+          bpmnReplace.replaceElement(el, target);
+
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          el = elementRegistry.get(element);
+          const executionListenersContainer = getExecutionListenersContainer(el);
+
+          expect(executionListenersContainer).not.to.exist;
+        }));
+      });
+    }
+  });
+
+  describe('remove execution listeners of disallowed type', function() {
+
+    const testCases = [
+      {
+        title: 'End Event -> Start Event',
+        element: 'EndEvent',
+        target: {
+          type: 'bpmn:StartEvent'
+        }
+      }
+    ];
+
+    for (const { title, element, target } of testCases) {
+
+      describe(title, function() {
+
+        it('should execute', inject(function(bpmnReplace, elementRegistry) {
+
+          // given
+          let el = elementRegistry.get(element);
+
+          // when
+          bpmnReplace.replaceElement(el, target);
+
+          // then
+          el = elementRegistry.get(element);
+          const container = getExtensionElementsList(getBusinessObject(el), 'zeebe:ExecutionListeners')[0];
+
+          expect(container.get('listeners')).to.have.lengthOf(1);
+        }));
+
+
+        it('should undo', inject(function(bpmnReplace, commandStack, elementRegistry) {
+
+          // given
+          let el = elementRegistry.get(element);
+
+          // when
+          bpmnReplace.replaceElement(el, target);
+
+          commandStack.undo();
+
+          // then
+          el = elementRegistry.get(element);
+          const container = getExtensionElementsList(getBusinessObject(el), 'zeebe:ExecutionListeners')[0];
+
+          expect(container.get('listeners')).to.have.lengthOf(2);
+        }));
+
+
+        it('should redo', inject(function(bpmnReplace, commandStack, elementRegistry) {
+
+          // given
+          let el = elementRegistry.get(element);
+
+          // when
+          bpmnReplace.replaceElement(el, target);
+
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          el = elementRegistry.get(element);
+          const container = getExtensionElementsList(getBusinessObject(el), 'zeebe:ExecutionListeners')[0];
+
+          expect(container.get('listeners')).to.have.lengthOf(1);
+        }));
+      });
+    }
+
+
+    it('should remove zeebe:ExecutionListeners', inject(function(elementRegistry, modeling) {
+
+      // given
+      const el = elementRegistry.get('SingleListener');
+      const listenersContainer = getExecutionListenersContainer(el);
+
+      // when
+      modeling.updateModdleProperties(el, listenersContainer, { listeners: [] });
+
+      // then
+      const extensionElements = getBusinessObject(el).get('extensionElements');
+
+      expect(extensionElements.get('values')).to.have.lengthOf(1);
+    }));
+  });
+});
+
+function getExecutionListenersContainer(element) {
+  return getExtensionElementsList(getBusinessObject(element), 'zeebe:ExecutionListeners')[0];
+}

--- a/test/camunda-cloud/execution-listeners.bpmn
+++ b/test/camunda-cloud/execution-listeners.bpmn
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0qh9wc7" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process" name="Execution Listeners Test" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:executionListeners>
+        <zeebe:executionListener eventType="start" retries="3" type="sysout" />
+        <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+      </zeebe:executionListeners>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+          <zeebe:executionListener eventType="end" retries="3" type="another" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    </bpmn:startEvent>
+    <bpmn:intermediateThrowEvent id="IntermediateThrowEvent">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="sysout" />
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="EndEvent">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="sysout" />
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="TimerEndEvent">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+          <zeebe:executionListener eventType="end" retries="3" type="another" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_2" />
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="sysout" />
+          <zeebe:executionListener eventType="start" retries="3" type="another" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    </bpmn:exclusiveGateway>
+    <bpmn:task id="Task">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="sysout" />
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    </bpmn:task>
+    <bpmn:subProcess id="SubProcess">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="sysout" />
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:startEvent id="SingleListener">
+        <bpmn:extensionElements>
+          <zeebe:executionListeners>
+            <zeebe:executionListener eventType="end" retries="3" type="another" />
+          </zeebe:executionListeners>
+          <zeebe:properties>
+            <zeebe:property name="key" value="value" />
+          </zeebe:properties>
+        </bpmn:extensionElements>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent" attachedToRef="SubProcess">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="end" retries="3" type="another" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0jqwplw" />
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNShape id="StartEvent_di" bpmnElement="StartEvent">
+        <dc:Bounds x="192" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateThrowEvent_di" bpmnElement="IntermediateThrowEvent">
+        <dc:Bounds x="192" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_di" bpmnElement="EndEvent">
+        <dc:Bounds x="192" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TimerEndEvent_di" bpmnElement="TimerEndEvent">
+        <dc:Bounds x="292" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_di" bpmnElement="Gateway" isMarkerVisible="true">
+        <dc:Bounds x="185" y="315" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_di" bpmnElement="Task">
+        <dc:Bounds x="160" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_di" bpmnElement="SubProcess" isExpanded="true">
+        <dc:Bounds x="160" y="510" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SingleListener_di" bpmnElement="SingleListener">
+        <dc:Bounds x="200" y="592" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_di" bpmnElement="BoundaryEvent">
+        <dc:Bounds x="492" y="692" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
This PR adds support for `zeebe:ExecutionListener` according to the support table in https://github.com/camunda/camunda-docs/pull/4017

In the implementation, we don't care about element types which are not currently supported in Camunda, e.g.
* adhoc subprocesses
* transacations
* complex gateway
* conditional events
