### PR TITLE
Remove `zeebe:bindingType` unless allowed

### DIFF
--- a/lib/camunda-cloud/FormsBehavior.js
+++ b/lib/camunda-cloud/FormsBehavior.js
@@ -138,6 +138,10 @@ export default class FormsBehavior extends CommandInterceptor {
      * 2. zeebe:FormDefinition with zeebe:formKey in the format of camunda-forms:bpmn:UserTaskForm_1 (embedded Camunda form)
      * 3. zeebe:FormDefinition with zeebe:formKey (custom form)
      * 4. zeebe:FormDefinition with zeebe:externalReference (external form)
+     *
+     * Furthermore, ensure that:
+     *
+     * 1. zeebe:bindingType only exists if zeebe:formId is set (linked Camunda form)
      */
     this.preExecute('element.updateModdleProperties', function(context) {
       const {
@@ -152,8 +156,16 @@ export default class FormsBehavior extends CommandInterceptor {
         } else if ('formKey' in properties) {
           properties.formId = undefined;
           properties.externalReference = undefined;
+          properties.bindingType = undefined;
         } else if ('externalReference' in properties) {
           properties.formId = undefined;
+          properties.formKey = undefined;
+          properties.bindingType = undefined;
+        }
+
+        if ('bindingType' in properties && !('formId' in properties) && !moddleElement.get('formId')) {
+          properties.externalReference = undefined;
+          properties.formId = '';
           properties.formKey = undefined;
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "sinon": "^17.0.1",
         "sinon-chai": "^3.7.0",
         "webpack": "^5.74.0",
-        "zeebe-bpmn-moddle": "^1.2.0"
+        "zeebe-bpmn-moddle": "^1.4.0"
       },
       "peerDependencies": {
         "bpmn-js": ">= 9",
@@ -7303,11 +7303,10 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.2.0.tgz",
-      "integrity": "sha512-KtY9CYs2qYKQMV7xdLY7Oj7Mgb0fA13DD8T0bYwv3JOkdqfW4IIqm+aMD+vvZ4j+2iaCGaqEA6XKHS5sZKG3Fg==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.4.0.tgz",
+      "integrity": "sha512-XSm0fMHPjQ5cmEGxga02du9arxb5NKH5ve7VQ0LFSes4wGcrZ/oJjaR3NlBqH6xTTD3g+Mcbh45+yesydPUQPg==",
+      "dev": true
     },
     "node_modules/zod": {
       "version": "3.23.8",
@@ -12704,9 +12703,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.2.0.tgz",
-      "integrity": "sha512-KtY9CYs2qYKQMV7xdLY7Oj7Mgb0fA13DD8T0bYwv3JOkdqfW4IIqm+aMD+vvZ4j+2iaCGaqEA6XKHS5sZKG3Fg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.4.0.tgz",
+      "integrity": "sha512-XSm0fMHPjQ5cmEGxga02du9arxb5NKH5ve7VQ0LFSes4wGcrZ/oJjaR3NlBqH6xTTD3g+Mcbh45+yesydPUQPg==",
       "dev": true
     },
     "zod": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "webpack": "^5.74.0",
-    "zeebe-bpmn-moddle": "^1.2.0"
+    "zeebe-bpmn-moddle": "^1.4.0"
   },
   "peerDependencies": {
     "bpmn-js": ">= 9",

--- a/test/camunda-cloud/FormsBehaviorSpec.js
+++ b/test/camunda-cloud/FormsBehaviorSpec.js
@@ -338,6 +338,25 @@ describe('camunda-cloud/features/modeling - FormsBehavior', function() {
         expect(extensionElements).not.to.exist;
       }));
 
+
+      it('should not remove binding type', inject(function(elementRegistry, modeling) {
+
+        // given
+        const userTask = elementRegistry.get('UserTask_12');
+
+        const formDefinition = getFormDefinition(userTask);
+
+        expect(formDefinition.get('bindingType')).to.equal('deployment');
+
+        // when
+        modeling.updateModdleProperties(userTask, formDefinition, {
+          formId: 'foobar'
+        });
+
+        // then
+        expect(formDefinition.get('bindingType')).to.equal('deployment');
+      }));
+
     });
 
 
@@ -404,6 +423,25 @@ describe('camunda-cloud/features/modeling - FormsBehavior', function() {
         expect(extensionElements).not.to.exist;
       }));
 
+
+      it('should remove binding type', inject(function(elementRegistry, modeling) {
+
+        // given
+        const userTask = elementRegistry.get('UserTask_12');
+
+        const formDefinition = getFormDefinition(userTask);
+
+        expect(formDefinition.get('bindingType')).to.equal('deployment');
+
+        // when
+        modeling.updateModdleProperties(userTask, formDefinition, {
+          formKey: 'foobar'
+        });
+
+        // then
+        expect(formDefinition.get('bindingType')).to.equal('latest'); // default value
+      }));
+
     });
 
 
@@ -424,6 +462,51 @@ describe('camunda-cloud/features/modeling - FormsBehavior', function() {
         // then
         expect(formDefinition.get('formId')).not.to.exist;
       }));
+
+
+      it('should remove binding type', inject(function(elementRegistry, modeling) {
+
+        // given
+        const userTask = elementRegistry.get('UserTask_12');
+
+        const formDefinition = getFormDefinition(userTask);
+
+        expect(formDefinition.get('bindingType')).to.equal('deployment');
+
+        // when
+        modeling.updateModdleProperties(userTask, formDefinition, {
+          externalReference: 'foobar'
+        });
+
+        // then
+        expect(formDefinition.get('bindingType')).to.equal('latest'); // default value
+      }));
+
+    });
+
+
+    describe('set binding type', function() {
+
+      it('should set form ID', inject(function(elementRegistry, modeling) {
+
+        // given
+        const userTask = elementRegistry.get('UserTask_1');
+
+        const formDefinition = getFormDefinition(userTask);
+
+        expect(formDefinition.get('bindingType')).to.equal('latest'); // default value
+        expect(formDefinition.get('formId')).not.to.exist;
+
+        // when
+        modeling.updateModdleProperties(userTask, formDefinition, {
+          bindingType: 'deployment'
+        });
+
+        // then
+        expect(formDefinition.get('bindingType')).to.equal('deployment');
+        expect(formDefinition.get('formId')).to.equal('');
+      }));
+
     });
 
 
@@ -543,6 +626,22 @@ describe('camunda-cloud/features/modeling - FormsBehavior', function() {
         expect(formDefinition.externalReference).not.to.exist;
         expect(formDefinition.formId).to.eql(originalFormId);
       }));
+
+
+      it('should keep binding type', inject(function(elementRegistry) {
+
+        // given
+        const userTask = elementRegistry.get('UserTask_12');
+
+        expect(getFormDefinition(userTask).get('bindingType')).to.equal('deployment');
+
+        // when
+        addZeebeUserTask(userTask);
+
+        // then
+        expect(getFormDefinition(userTask).get('bindingType')).to.equal('deployment');
+      }));
+
     });
 
 
@@ -599,6 +698,21 @@ describe('camunda-cloud/features/modeling - FormsBehavior', function() {
         expect(formDefinition.formKey).not.to.exist;
         expect(formDefinition.externalReference).not.to.exist;
         expect(formDefinition.formId).to.eql(originalFormId);
+      }));
+
+
+      it('should keep binding type', inject(function(elementRegistry) {
+
+        // given
+        const userTask = elementRegistry.get('UserTask_12');
+
+        expect(getFormDefinition(userTask).get('bindingType')).to.equal('deployment');
+
+        // when
+        removeZeebeUserTask(userTask);
+
+        // then
+        expect(getFormDefinition(userTask).get('bindingType')).to.equal('deployment');
       }));
 
     });

--- a/test/camunda-cloud/process-user-tasks.bpmn
+++ b/test/camunda-cloud/process-user-tasks.bpmn
@@ -65,7 +65,7 @@
     </bpmn:userTask>
     <bpmn:userTask id="UserTask_12" name="UserTask_12">
       <bpmn:extensionElements>
-        <zeebe:formDefinition formId="foobar" />
+        <zeebe:formDefinition formId="foobar" bindingType="deployment" />
       </bpmn:extensionElements>
     </bpmn:userTask>
     <bpmn:userTask id="withExternalReference" name="With external reference">


### PR DESCRIPTION
* removes `zeebe:bindingType` when `zeebe:formId` (linked Camunda form) is removed
* sets `zeebe:formId` when `zeebe:bindingType` is set

Related to https://github.com/camunda/camunda-modeler/issues/4385