### PR TITLE
Add `zeebe:VersionTag` behavior

### DIFF
--- a/lib/camunda-cloud/VersionTagBehavior.js
+++ b/lib/camunda-cloud/VersionTagBehavior.js
@@ -1,0 +1,50 @@
+import { isDefined } from 'min-dash';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+import { isAny } from 'bpmn-js/lib/util/ModelUtil';
+
+/**
+ * Zeebe BPMN specific version tag behavior.
+ */
+export default class VersionTagBehavior extends CommandInterceptor {
+  constructor(eventBus) {
+    super(eventBus);
+
+    /**
+     * Ensure that `zeebe:BindingTypeSupported` (`zeebe:CalledDecision`,
+     * `zeebe:CalledElement` and `zeebe:FormDefinition`) only has
+     * `zeebe:versionTag` if `zeebe:bindingType` is `versionTag`.
+     */
+    this.preExecute('element.updateModdleProperties', function(context) {
+      const {
+        moddleElement,
+        properties
+      } = context;
+
+      if (!isAny(moddleElement, [
+        'zeebe:CalledDecision',
+        'zeebe:CalledElement',
+        'zeebe:FormDefinition'
+      ])) {
+        return;
+      }
+
+      // unset `zeebe:versionTag` if `zeebe:bindingType` is not set to `versionTag`
+      if ('bindingType' in properties
+        && properties.bindingType !== 'versionTag'
+        && isDefined(moddleElement.get('versionTag'))) {
+        properties.versionTag = undefined;
+      }
+
+      // set `zeebe:bindingType` to `versionTag` if `zeebe:versionTag` is set
+      if ('versionTag' in properties && moddleElement.get('bindingType') !== 'versionTag') {
+        properties.bindingType = 'versionTag';
+      }
+    }, true);
+  }
+}
+
+VersionTagBehavior.$inject = [
+  'eventBus'
+];

--- a/lib/camunda-cloud/index.js
+++ b/lib/camunda-cloud/index.js
@@ -9,6 +9,7 @@ import DeleteParticipantBehaviour from '../shared/DeleteParticipantBehaviour';
 import FormsBehavior from './FormsBehavior';
 import RemoveAssignmentDefinitionBehavior from './RemoveAssignmentDefinitionBehavior';
 import RemoveTaskScheduleBehavior from './RemoveTaskScheduleBehavior';
+import VersionTagBehavior from './VersionTagBehavior';
 
 export default {
   __init__: [
@@ -22,7 +23,8 @@ export default {
     'deleteParticipantBehaviour',
     'formsBehavior',
     'removeAssignmentDefinitionBehavior',
-    'removeTaskScheduleBehavior'
+    'removeTaskScheduleBehavior',
+    'versionTagBehavior'
   ],
   cleanUpBusinessRuleTaskBehavior: [ 'type', CleanUpBusinessRuleTaskBehavior ],
   cleanUpEndEventBehavior: [ 'type', CleanUpEndEventBehavior ],
@@ -34,5 +36,6 @@ export default {
   deleteParticipantBehaviour: [ 'type', DeleteParticipantBehaviour ],
   formsBehavior: [ 'type', FormsBehavior ],
   removeAssignmentDefinitionBehavior: [ 'type', RemoveAssignmentDefinitionBehavior ],
-  removeTaskScheduleBehavior: [ 'type', RemoveTaskScheduleBehavior ]
+  removeTaskScheduleBehavior: [ 'type', RemoveTaskScheduleBehavior ],
+  versionTagBehavior: [ 'type', VersionTagBehavior ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "sinon": "^17.0.1",
         "sinon-chai": "^3.7.0",
         "webpack": "^5.74.0",
-        "zeebe-bpmn-moddle": "^1.4.0"
+        "zeebe-bpmn-moddle": "^1.6.0"
       },
       "peerDependencies": {
         "bpmn-js": ">= 9",
@@ -7276,9 +7276,9 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.4.0.tgz",
-      "integrity": "sha512-XSm0fMHPjQ5cmEGxga02du9arxb5NKH5ve7VQ0LFSes4wGcrZ/oJjaR3NlBqH6xTTD3g+Mcbh45+yesydPUQPg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.6.0.tgz",
+      "integrity": "sha512-vjPeJoLQs7UkC5m27K0CyZkQMEAI8GsISU6TcfD2n/SzqkhJ6tubvcIabLRAhreaiuHY26MjtSVXw1LRVgd7Iw==",
       "dev": true
     },
     "node_modules/zod": {
@@ -12668,9 +12668,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.4.0.tgz",
-      "integrity": "sha512-XSm0fMHPjQ5cmEGxga02du9arxb5NKH5ve7VQ0LFSes4wGcrZ/oJjaR3NlBqH6xTTD3g+Mcbh45+yesydPUQPg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.6.0.tgz",
+      "integrity": "sha512-vjPeJoLQs7UkC5m27K0CyZkQMEAI8GsISU6TcfD2n/SzqkhJ6tubvcIabLRAhreaiuHY26MjtSVXw1LRVgd7Iw==",
       "dev": true
     },
     "zod": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "webpack": "^5.74.0",
-    "zeebe-bpmn-moddle": "^1.4.0"
+    "zeebe-bpmn-moddle": "^1.6.0"
   },
   "peerDependencies": {
     "bpmn-js": ">= 9",

--- a/test/camunda-cloud/VersionTagBehaviorSpec.js
+++ b/test/camunda-cloud/VersionTagBehaviorSpec.js
@@ -1,0 +1,94 @@
+import {
+  bootstrapCamundaCloudModeler,
+  inject
+} from 'test/TestHelper';
+
+import {
+  getBusinessObject,
+  isAny
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import diagramXML from './version-tag.bpmn';
+
+
+describe('camunda-cloud/features/modeling - VersionTagBehavior', function() {
+
+  beforeEach(bootstrapCamundaCloudModeler(diagramXML));
+
+
+  [
+    'CallActivity',
+    'BusinessRuleTask',
+    'UserTask'
+  ].forEach(function(type) {
+
+    describe('unset version tag', function() {
+
+      it('should unset version tag', inject(function(elementRegistry, modeling) {
+
+        // given
+        const element = elementRegistry.get(`${ type }_1`);
+
+        const extensionElement = getExtensionElement(element);
+
+        expect(extensionElement.get('bindingType')).to.equal('versionTag');
+        expect(extensionElement.get('versionTag')).to.equal('v1.0.0');
+
+        // when
+        modeling.updateModdleProperties(element, extensionElement, {
+          bindingType: 'deployment'
+        });
+
+        // then
+        expect(extensionElement.get('bindingType')).to.equal('deployment');
+        expect(extensionElement.get('versionTag')).not.to.exist;
+      }));
+
+    });
+
+    describe('set binding type', function() {
+
+      it('should set binding type', inject(function(elementRegistry, modeling) {
+
+        // given
+        const element = elementRegistry.get(`${ type }_2`);
+
+        const extensionElement = getExtensionElement(element);
+
+        expect(extensionElement.get('bindingType')).to.equal('deployment');
+
+        // when
+        modeling.updateModdleProperties(element, extensionElement, {
+          versionTag: 'v1.0.0'
+        });
+
+        // then
+        expect(extensionElement.get('bindingType')).to.equal('versionTag');
+        expect(extensionElement.get('versionTag')).to.equal('v1.0.0');
+      }));
+
+    });
+
+  });
+
+});
+
+// helpers //////////
+
+function getExtensionElement(element) {
+  const businessObject = getBusinessObject(element);
+
+  const extensionElements = businessObject.get('extensionElements');
+
+  if (!extensionElements) {
+    return null;
+  }
+
+  return extensionElements.get('values').find(extensionElement => {
+    return isAny(extensionElement, [
+      'zeebe:CalledDecision',
+      'zeebe:CalledElement',
+      'zeebe:FormDefinition'
+    ]);
+  });
+}

--- a/test/camunda-cloud/version-tag.bpmn
+++ b/test/camunda-cloud/version-tag.bpmn
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0949dru" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="Process_0xt54td" isExecutable="true">
+    <bpmn:callActivity id="CallActivity_1">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllChildVariables="false" bindingType="versionTag" versionTag="v1.0.0" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:businessRuleTask id="BusinessRuleTask_1">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision bindingType="versionTag" versionTag="v1.0.0" />
+      </bpmn:extensionElements>
+    </bpmn:businessRuleTask>
+    <bpmn:userTask id="UserTask_1">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="" bindingType="versionTag" versionTag="v1.0.0" />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+    <bpmn:callActivity id="CallActivity_2">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllChildVariables="false" bindingType="deployment" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:businessRuleTask id="BusinessRuleTask_2">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision bindingType="deployment" />
+      </bpmn:extensionElements>
+    </bpmn:businessRuleTask>
+    <bpmn:userTask id="UserTask_2">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="" bindingType="deployment" />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0xt54td">
+      <bpmndi:BPMNShape id="Activity_04qoo0e_di" bpmnElement="CallActivity_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0rpa9kq_di" bpmnElement="BusinessRuleTask_1">
+        <dc:Bounds x="290" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1t7eh0a_di" bpmnElement="UserTask_1">
+        <dc:Bounds x="420" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ad2nfv_di" bpmnElement="CallActivity_2">
+        <dc:Bounds x="160" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ylf3wd_di" bpmnElement="BusinessRuleTask_2">
+        <dc:Bounds x="290" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09ac9pr_di" bpmnElement="UserTask_2">
+        <dc:Bounds x="420" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Adds behavior ensuring that `zeebe:BindingTypeSupported` (`zeebe:CalledDecision`, `zeebe:CalledElement` and `zeebe:FormDefinition`) only has `zeebe:versionTag` if `zeebe:bindingType` is `versionTag`.

Related to https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1063

