### PR TITLE
fix(zeebe): remove empty `zeebe:VersionTag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [camunda-bpmn-js-behaviors](https://github.com/camunda/ca
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.6.1
+
+* `FIX`: remove empty `zeebe:VersionTag` ([#81](https://github.com/camunda/camunda-bpmn-js-behaviors/pull/81))
+
 ## 1.6.0
 
 * `FEAT`: support `zeebe:versionTag` for `zeebe:CalledDecision`, `zeebe:CalledElement` and `zeebe:FormDefinition` ([#80](https://github.com/camunda/camunda-bpmn-js-behaviors/pull/80))

--- a/lib/camunda-cloud/VersionTagBehavior.js
+++ b/lib/camunda-cloud/VersionTagBehavior.js
@@ -2,13 +2,18 @@ import { isDefined } from 'min-dash';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
-import { isAny } from 'bpmn-js/lib/util/ModelUtil';
+import {
+  getBusinessObject,
+  is,
+  isAny
+} from 'bpmn-js/lib/util/ModelUtil';
+import { removeExtensionElements } from '../util/ExtensionElementsUtil';
 
 /**
  * Zeebe BPMN specific version tag behavior.
  */
 export default class VersionTagBehavior extends CommandInterceptor {
-  constructor(eventBus) {
+  constructor(eventBus, commandStack) {
     super(eventBus);
 
     /**
@@ -42,9 +47,34 @@ export default class VersionTagBehavior extends CommandInterceptor {
         properties.bindingType = 'versionTag';
       }
     }, true);
+
+    /**
+     * Remove `zeebe:VersionTag` if its value is empty.
+     */
+    this.postExecuted('element.updateModdleProperties', function(context) {
+      const {
+        element,
+        moddleElement
+      } = context;
+
+      if (!is(moddleElement, 'zeebe:VersionTag')) {
+        return;
+      }
+
+      if (isEmpty(moddleElement.get('value'))) {
+        removeExtensionElements(element, getBusinessObject(element), moddleElement, commandStack);
+      }
+    }, true);
   }
 }
 
 VersionTagBehavior.$inject = [
-  'eventBus'
+  'eventBus',
+  'commandStack'
 ];
+
+// helpers //////////
+
+function isEmpty(value) {
+  return value == undefined || value === '';
+}

--- a/test/camunda-cloud/VersionTagBehaviorSpec.js
+++ b/test/camunda-cloud/VersionTagBehaviorSpec.js
@@ -5,6 +5,7 @@ import {
 
 import {
   getBusinessObject,
+  is,
   isAny
 } from 'bpmn-js/lib/util/ModelUtil';
 
@@ -29,7 +30,7 @@ describe('camunda-cloud/features/modeling - VersionTagBehavior', function() {
         // given
         const element = elementRegistry.get(`${ type }_1`);
 
-        const extensionElement = getExtensionElement(element);
+        const extensionElement = getExtensionElementWithVersionTag(element);
 
         expect(extensionElement.get('bindingType')).to.equal('versionTag');
         expect(extensionElement.get('versionTag')).to.equal('v1.0.0');
@@ -53,7 +54,7 @@ describe('camunda-cloud/features/modeling - VersionTagBehavior', function() {
         // given
         const element = elementRegistry.get(`${ type }_2`);
 
-        const extensionElement = getExtensionElement(element);
+        const extensionElement = getExtensionElementWithVersionTag(element);
 
         expect(extensionElement.get('bindingType')).to.equal('deployment');
 
@@ -71,11 +72,35 @@ describe('camunda-cloud/features/modeling - VersionTagBehavior', function() {
 
   });
 
+
+  describe('remove version tag', function() {
+
+    it('should remove version tag', inject(function(elementRegistry, modeling) {
+
+      // given
+      const element = elementRegistry.get('Process_1');
+
+      const versionTag = getVersionTag(element);
+
+      // assume
+      expect(versionTag).to.exist;
+
+      // when
+      modeling.updateModdleProperties(element, versionTag, {
+        value: ''
+      });
+
+      // then
+      expect(getVersionTag(element)).not.to.exist;
+    }));
+
+  });
+
 });
 
 // helpers //////////
 
-function getExtensionElement(element) {
+function getExtensionElementWithVersionTag(element) {
   const businessObject = getBusinessObject(element);
 
   const extensionElements = businessObject.get('extensionElements');
@@ -90,5 +115,19 @@ function getExtensionElement(element) {
       'zeebe:CalledElement',
       'zeebe:FormDefinition'
     ]);
+  });
+}
+
+function getVersionTag(element) {
+  const businessObject = getBusinessObject(element);
+
+  const extensionElements = businessObject.get('extensionElements');
+
+  if (!extensionElements) {
+    return null;
+  }
+
+  return extensionElements.get('values').find(extensionElement => {
+    return is(extensionElement, 'zeebe:VersionTag');
   });
 }

--- a/test/camunda-cloud/version-tag.bpmn
+++ b/test/camunda-cloud/version-tag.bpmn
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0949dru" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
-  <bpmn:process id="Process_0xt54td" isExecutable="true">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:versionTag value="v1.0.0" />
+    </bpmn:extensionElements>
     <bpmn:callActivity id="CallActivity_1">
       <bpmn:extensionElements>
         <zeebe:calledElement propagateAllChildVariables="false" bindingType="versionTag" versionTag="v1.0.0" />
@@ -33,7 +36,7 @@
     </bpmn:userTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0xt54td">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="Activity_04qoo0e_di" bpmnElement="CallActivity_1">
         <dc:Bounds x="160" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>


### PR DESCRIPTION
Not removing empty `zeebe:VersionTag` extension elements will result in a linting error. Furthermore, it doesn't make sense to keep an empty version tag.