### PR TITLE
feat: support `zeebe:AdHoc`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "sinon": "^17.0.1",
         "sinon-chai": "^3.7.0",
         "webpack": "^5.74.0",
-        "zeebe-bpmn-moddle": "^1.7.0"
+        "zeebe-bpmn-moddle": "^1.9.0"
       },
       "peerDependencies": {
         "bpmn-js": ">= 9",
@@ -7867,11 +7867,10 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.7.0.tgz",
-      "integrity": "sha512-eZ6OXSt0c4n9V/oN/46gTlwDIS3GhWQLt9jbM5uS/YryB4yN8wdrrKrtw+TpyNy0SSKWXNDHyC83nCA2blPO3Q==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.9.0.tgz",
+      "integrity": "sha512-Y9ncIdP4m1PKbIBDqSghwZud2eiiBpfygE0bTApGqtnGlJMA/6Xanl/J7ujxG5zREoAliwf6rJyJFk3FZ75AYg==",
+      "dev": true
     },
     "node_modules/zod": {
       "version": "3.23.8",
@@ -13656,9 +13655,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.7.0.tgz",
-      "integrity": "sha512-eZ6OXSt0c4n9V/oN/46gTlwDIS3GhWQLt9jbM5uS/YryB4yN8wdrrKrtw+TpyNy0SSKWXNDHyC83nCA2blPO3Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.9.0.tgz",
+      "integrity": "sha512-Y9ncIdP4m1PKbIBDqSghwZud2eiiBpfygE0bTApGqtnGlJMA/6Xanl/J7ujxG5zREoAliwf6rJyJFk3FZ75AYg==",
       "dev": true
     },
     "zod": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "webpack": "^5.74.0",
-    "zeebe-bpmn-moddle": "^1.7.0"
+    "zeebe-bpmn-moddle": "^1.9.0"
   },
   "peerDependencies": {
     "bpmn-js": ">= 9",

--- a/test/camunda-cloud/ZeebeAdHocBehaviorSpec.js
+++ b/test/camunda-cloud/ZeebeAdHocBehaviorSpec.js
@@ -1,0 +1,32 @@
+import {
+  bootstrapCamundaCloudModeler,
+  inject
+} from 'test/TestHelper';
+
+import { getExtensionElementsList } from 'lib/util/ExtensionElementsUtil';
+
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import diagramXML from './zeebe-ad-hoc.bpmn';
+
+
+describe('camunda-cloud/features/modeling - ZeebeAdHocBehaviorSpec', function() {
+
+  beforeEach(bootstrapCamundaCloudModeler(diagramXML));
+
+  it('should remove zeebe:AdHoc for non ad-hoc sub process', inject(function(bpmnReplace, elementRegistry) {
+
+    // given
+    const subprocess = elementRegistry.get('Adhoc_Subprocess');
+
+    // when
+    const result = bpmnReplace.replaceElement(subprocess, {
+      type: 'bpmn:SubProcess'
+    });
+
+    // then
+    const extensionElements = getExtensionElementsList(getBusinessObject(result));
+    expect(extensionElements).to.have.lengthOf(0);
+  }));
+
+});

--- a/test/camunda-cloud/zeebe-ad-hoc.bpmn
+++ b/test/camunda-cloud/zeebe-ad-hoc.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="simple" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL bpmn0.xsd">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:adHocSubProcess id="Adhoc_Subprocess">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=items" />
+      </bpmn:extensionElements>
+      <bpmn:task id="Activity_1u00137" />
+      <bpmn:task id="Activity_0b2gnz4" />
+    </bpmn:adHocSubProcess>
+    <bpmn:subProcess id="Subprocess">
+      <bpmn:task id="Activity_170vlk4" />
+      <bpmn:task id="Activity_15c5abi" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="BPMNShape_1pgqyy7" bpmnElement="Adhoc_Subprocess" isExpanded="true">
+        <dc:Bounds x="510" y="80" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0w1g1io" bpmnElement="Activity_1u00137">
+        <dc:Bounds x="545" y="140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0r2twic" bpmnElement="Activity_0b2gnz4">
+        <dc:Bounds x="695" y="140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1bhia20_di" bpmnElement="Subprocess" isExpanded="true">
+        <dc:Bounds x="125" y="80" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_170vlk4_di" bpmnElement="Activity_170vlk4">
+        <dc:Bounds x="160" y="140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_15c5abi_di" bpmnElement="Activity_15c5abi">
+        <dc:Bounds x="310" y="140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Make sure `zeebe:AdHoc` is removed from element when it's no longer a `bpmn:AdHocSubProcess`.

Update to `zeebe-bpmn-moddle@1.9.0`

Related to https://github.com/camunda/camunda-modeler/issues/4739