### PR TITLE
Disallow message ref in throw event and send task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to [camunda-bpmn-js-behaviors](https://github.com/camunda/ca
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.10.0
+
+* `DEPS`: update to `bpmn-js@18.6.1`
+* `FEAT`: remove message ref when replacing with send task or throw event
+
 ## 1.9.1
 
 * `DEPS`: update to `zeebe-bpmn-moddle@1.9.0`

--- a/lib/camunda-cloud/CleanUpMessageRefBehavior.js
+++ b/lib/camunda-cloud/CleanUpMessageRefBehavior.js
@@ -1,0 +1,65 @@
+import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+
+export default class CleanUpMessageRefBehavior extends CommandInterceptor {
+  constructor(eventBus, modeling) {
+    super(eventBus, modeling);
+
+    this.postExecuted('shape.replace', function(event) {
+      const newShape = event.context.newShape;
+
+      if (!is(newShape, 'bpmn:ThrowEvent')) {
+        return;
+      }
+
+      const messageEventDefinition = getMessageEventDefinition(newShape);
+
+      if (!messageEventDefinition) {
+        return;
+      }
+
+      const messageRef = messageEventDefinition.get('messageRef');
+      if (!messageRef) {
+        return;
+      }
+
+      modeling.updateModdleProperties(newShape, messageEventDefinition, {
+        messageRef: undefined
+      });
+    });
+
+    this.postExecuted('shape.replace', function(event) {
+      const newShape = event.context.newShape,
+            bo = getBusinessObject(newShape);
+
+      if (!is(bo, 'bpmn:SendTask')) {
+        return;
+      }
+
+      const messageRef = bo.get('messageRef');
+      if (!messageRef) {
+        return;
+      }
+
+      modeling.updateProperties(newShape, {
+        messageRef: undefined
+      });
+    });
+  }
+}
+
+CleanUpMessageRefBehavior.$inject = [ 'eventBus', 'modeling' ];
+
+
+// helpers //////////
+
+function getMessageEventDefinition(element) {
+  const businessObject = getBusinessObject(element);
+
+  const eventDefinitions = businessObject.get('eventDefinitions') || [];
+
+  return eventDefinitions.find(definition => {
+    return is(definition, 'bpmn:MessageEventDefinition');
+  });
+}

--- a/lib/camunda-cloud/index.js
+++ b/lib/camunda-cloud/index.js
@@ -1,6 +1,7 @@
 import CleanUpBusinessRuleTaskBehavior from './CleanUpBusinessRuleTaskBehavior';
 import CleanUpEndEventBehavior from './CleanUpEndEventBehavior';
 import CleanUpExecutionListenersBehavior from './CleanUpExecutionListenersBehavior';
+import CleanUpMessageRefBehavior from './CleanUpMessageRefBehavior';
 import CleanUpTaskListenersBehavior from './CleanUpTaskListenersBehavior';
 import CleanUpSubscriptionBehavior from './CleanUpSubscriptionBehavior';
 import CleanUpTimerExpressionBehavior from './CleanUpTimerExpressionBehavior';
@@ -18,6 +19,7 @@ export default {
     'cleanUpBusinessRuleTaskBehavior',
     'cleanUpEndEventBehavior',
     'cleanUpExecutionListenersBehavior',
+    'cleanUpMessageRefBehavior',
     'cleanUpTaskListenersBehavior',
     'cleanUpSubscriptionBehavior',
     'cleanUpTimerExpressionBehavior',
@@ -33,6 +35,7 @@ export default {
   cleanUpBusinessRuleTaskBehavior: [ 'type', CleanUpBusinessRuleTaskBehavior ],
   cleanUpEndEventBehavior: [ 'type', CleanUpEndEventBehavior ],
   cleanUpExecutionListenersBehavior: [ 'type', CleanUpExecutionListenersBehavior ],
+  cleanUpMessageRefBehavior: [ 'type', CleanUpMessageRefBehavior ],
   cleanUpTaskListenersBehavior: [ 'type', CleanUpTaskListenersBehavior ],
   cleanUpSubscriptionBehavior: [ 'type', CleanUpSubscriptionBehavior ],
   cleanUpTimerExpressionBehavior: [ 'type', CleanUpTimerExpressionBehavior ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@babel/core": "^7.23.7",
         "babel-loader": "^10.0.0",
         "babel-plugin-istanbul": "^7.0.0",
-        "bpmn-js": "^18.0.0",
+        "bpmn-js": "^18.6.1",
         "camunda-bpmn-moddle": "^7.0.1",
         "chai": "^4.4.1",
         "cross-env": "^7.0.3",
@@ -1628,13 +1628,14 @@
       }
     },
     "node_modules/bpmn-js": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.0.0.tgz",
-      "integrity": "sha512-eZR4hqk2BT0m9jAGGtp/f1TD0m7LXXKfYle99q75d+NjSmxetIuvxGn48S9W+H8arJ7vgsls2GELzXoDuEE0eg==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.6.1.tgz",
+      "integrity": "sha512-4nZNJPnF1MOQD3U7zUOT5xK+3vn7vililk+xRuILoQuVFxUOBQ7iJzU/O4kRn5/paHMn86G3UHuTc2fHdgiSgQ==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^9.0.1",
-        "diagram-js": "^15.1.0",
+        "diagram-js": "^15.3.0",
         "diagram-js-direct-editing": "^3.2.0",
         "ids": "^1.0.5",
         "inherits-browser": "^0.1.0",
@@ -2393,10 +2394,11 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.1.0.tgz",
-      "integrity": "sha512-Lrixuc4as/PGrkhf23k8yss+rLhyH2Zrln/CJxex0nOfC2P0ODb5lsDY0+MdDgjP2ADFFINqUXAGFcSSL8tw4g==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.3.0.tgz",
+      "integrity": "sha512-Fjq+C8Bee2DhX9N3jpIUIhbqvSbP6oMD75n+y5UChcr34buApZFO+fXsv8a/SlW+tci+6nvc71vf17TBY/RJVg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.0",
@@ -8918,13 +8920,13 @@
       }
     },
     "bpmn-js": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.0.0.tgz",
-      "integrity": "sha512-eZR4hqk2BT0m9jAGGtp/f1TD0m7LXXKfYle99q75d+NjSmxetIuvxGn48S9W+H8arJ7vgsls2GELzXoDuEE0eg==",
+      "version": "18.6.1",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.6.1.tgz",
+      "integrity": "sha512-4nZNJPnF1MOQD3U7zUOT5xK+3vn7vililk+xRuILoQuVFxUOBQ7iJzU/O4kRn5/paHMn86G3UHuTc2fHdgiSgQ==",
       "dev": true,
       "requires": {
         "bpmn-moddle": "^9.0.1",
-        "diagram-js": "^15.1.0",
+        "diagram-js": "^15.3.0",
         "diagram-js-direct-editing": "^3.2.0",
         "ids": "^1.0.5",
         "inherits-browser": "^0.1.0",
@@ -9454,9 +9456,9 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.1.0.tgz",
-      "integrity": "sha512-Lrixuc4as/PGrkhf23k8yss+rLhyH2Zrln/CJxex0nOfC2P0ODb5lsDY0+MdDgjP2ADFFINqUXAGFcSSL8tw4g==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.3.0.tgz",
+      "integrity": "sha512-Fjq+C8Bee2DhX9N3jpIUIhbqvSbP6oMD75n+y5UChcr34buApZFO+fXsv8a/SlW+tci+6nvc71vf17TBY/RJVg==",
       "dev": true,
       "requires": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/core": "^7.23.7",
     "babel-loader": "^10.0.0",
     "babel-plugin-istanbul": "^7.0.0",
-    "bpmn-js": "^18.0.0",
+    "bpmn-js": "^18.6.1",
     "camunda-bpmn-moddle": "^7.0.1",
     "chai": "^4.4.1",
     "cross-env": "^7.0.3",

--- a/test/camunda-cloud/CleanUpMessageRefBehaviorSpec.js
+++ b/test/camunda-cloud/CleanUpMessageRefBehaviorSpec.js
@@ -1,0 +1,98 @@
+import {
+  bootstrapCamundaCloudModeler,
+  inject
+} from 'test/TestHelper';
+
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import diagramXML from './message.bpmn';
+
+
+describe('camunda-cloud/features/modeling - CleanUpMessageThrowEventBehavior', function() {
+
+  beforeEach(bootstrapCamundaCloudModeler(diagramXML));
+
+  describe('replace', function() {
+
+    it('should remove message ref when replacing with message throw event', inject(
+      function(elementRegistry, bpmnReplace) {
+
+        // given
+        let event = elementRegistry.get('Event');
+
+        // assume
+        expect(getMessageRef(event)).to.exist;
+
+        // when
+        bpmnReplace.replaceElement(event, {
+          type: 'bpmn:EndEvent',
+          eventDefinitionType: 'bpmn:MessageEventDefinition'
+        });
+
+        // then
+        event = elementRegistry.get('Event');
+        expect(getMessageRef(event)).not.to.exist;
+      }
+    ));
+
+
+    it('should remove message ref when replacing with send task', inject(
+      function(elementRegistry, bpmnReplace) {
+
+        // given
+        let task = elementRegistry.get('ReceiveTask');
+
+        // assume
+        expect(getMessageRef(task)).to.exist;
+
+        // when
+        bpmnReplace.replaceElement(task, {
+          type: 'bpmn:SendTask'
+        });
+
+        // then
+        task = elementRegistry.get('ReceiveTask');
+        expect(getMessageRef(task)).not.to.exist;
+      }
+    ));
+
+
+    it('should keep message ref when replacing with message catch event', inject(
+      function(elementRegistry, bpmnReplace) {
+
+        // given
+        let event = elementRegistry.get('Event');
+
+        // assume
+        expect(getMessageRef(event)).to.exist;
+
+        // when
+        bpmnReplace.replaceElement(event, {
+          type: 'bpmn:StartEvent',
+          eventDefinitionType: 'bpmn:MessageEventDefinition'
+        });
+
+        // then
+        event = elementRegistry.get('Event');
+        expect(getMessageRef(event)).to.exist;
+      }
+    ));
+  });
+
+
+});
+
+
+// helpers //////////
+
+function getMessageRef(element) {
+  const bo = getBusinessObject(element);
+  if (is(element, 'bpmn:Event')) {
+    return bo.get('eventDefinitions')[0].get('messageRef');
+  }
+
+  return bo.get('messageRef');
+}

--- a/test/camunda-cloud/message.bpmn
+++ b/test/camunda-cloud/message.bpmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0nxh8y3" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.33.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.3.0">
+  <bpmn:process id="Process_1qnptza" isExecutable="true">
+    <bpmn:intermediateCatchEvent id="Event">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0bwaev1" messageRef="Message_1lnjcbt" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:receiveTask id="ReceiveTask" messageRef="Message_1lnjcbt" />
+  </bpmn:process>
+  <bpmn:message id="Message_1lnjcbt" name="Message">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=abc" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1qnptza">
+      <bpmndi:BPMNShape id="Event_101rckl_di" bpmnElement="Event">
+        <dc:Bounds x="152" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1np9ut7_di" bpmnElement="ReceiveTask">
+        <dc:Bounds x="150" y="180" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
This PR:
* updates bpmn-js dependency to 18.6.1
* adds a new behavior to account for bpmn-js now copying references to target events
* updates changelog for 1.10.0 release

Related to https://github.com/camunda/camunda-modeler/issues/5003