### PR TITLE
fix: keep `zeebe:versionTag` unset if it's updated to with undefined

### DIFF
--- a/lib/camunda-cloud/VersionTagBehavior.js
+++ b/lib/camunda-cloud/VersionTagBehavior.js
@@ -43,7 +43,7 @@ export default class VersionTagBehavior extends CommandInterceptor {
       }
 
       // set `zeebe:bindingType` to `versionTag` if `zeebe:versionTag` is set
-      if ('versionTag' in properties && moddleElement.get('bindingType') !== 'versionTag') {
+      if (isDefined(properties.versionTag) && moddleElement.get('bindingType') !== 'versionTag') {
         properties.bindingType = 'versionTag';
       }
     }, true);

--- a/test/camunda-cloud/VersionTagBehaviorSpec.js
+++ b/test/camunda-cloud/VersionTagBehaviorSpec.js
@@ -46,11 +46,31 @@ describe('camunda-cloud/features/modeling - VersionTagBehavior', function() {
         expect(extensionElement.get('versionTag')).not.to.exist;
       }));
 
+
+      it('should keep version tag unset if version tag is undefined', inject(function(elementRegistry, modeling) {
+
+        // given
+        const element = elementRegistry.get(`${ type }_2`);
+
+        const extensionElement = getExtensionElementWithVersionTag(element);
+
+        expect(extensionElement.get('bindingType')).to.equal('deployment');
+
+        // when
+        modeling.updateModdleProperties(element, extensionElement, {
+          versionTag: undefined
+        });
+
+        // then
+        expect(extensionElement.get('bindingType')).to.equal('deployment');
+        expect(extensionElement.get('versionTag')).not.to.exist;
+      }));
+
     });
 
     describe('set binding type', function() {
 
-      it('should set binding type', inject(function(elementRegistry, modeling) {
+      it('should set binding type when setting versionTag', inject(function(elementRegistry, modeling) {
 
         // given
         const element = elementRegistry.get(`${ type }_2`);


### PR DESCRIPTION
Fixes a bug where the `bindingType` would be set to "versionTag" when the `versionTag` property was `undefined`

related to https://github.com/camunda/camunda-modeler/issues/5027

