### PR TITLE
Undo breaking change (verify that `cancelRemainingInstances` is correctly reset)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [camunda-bpmn-js-behaviors](https://github.com/camunda/ca
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.11.2
+
+* `DEPS`: update to `bpmn-js@18.6.4`
+
 ## 1.11.1
 
 * `FIX`: remove `bpmn:cancelRemainingInstances` when adding `zeebe:TaskDefinition` ([#106](https://github.com/camunda/camunda-bpmn-js-behaviors/pull/106))

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@babel/core": "^7.28.3",
         "babel-loader": "^10.0.0",
         "babel-plugin-istanbul": "^7.0.0",
-        "bpmn-js": "^18.6.3",
+        "bpmn-js": "^18.6.4",
         "camunda-bpmn-moddle": "^7.0.1",
         "chai": "^4.5.0",
         "cross-env": "^10.0.0",
@@ -1659,13 +1659,13 @@
       }
     },
     "node_modules/bpmn-js": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.6.3.tgz",
-      "integrity": "sha512-dNVZhzdxA6q9GFlc5UE691gBGSiGYjLcXbohQ65/P0ZUERgJi7z8Kgnu2f/rrizfE/jray+hAjMfZdFfOG/B+w==",
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.6.4.tgz",
+      "integrity": "sha512-8hvS+MD34ol1WYUqygY+OMDurD/pLt+ok7LC9lmQHqcQe21BDRXjDZpoNGZf/dwcth6Rec1zVAOhT8Um9Wk8FQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "bpmn-moddle": "^9.0.3",
+        "bpmn-moddle": "^9.0.4",
         "diagram-js": "^15.3.0",
         "diagram-js-direct-editing": "^3.2.0",
         "ids": "^1.0.5",
@@ -1679,9 +1679,9 @@
       }
     },
     "node_modules/bpmn-moddle": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-9.0.3.tgz",
-      "integrity": "sha512-Mv9KKKSaH5PsN5b1j7GoLfsQ9Ortm5o9Rj7Xy9hnsOhUSUJWIvlch//qYPUvaE6CS4uR6dtujOPum7mLIhl6xQ==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-9.0.4.tgz",
+      "integrity": "sha512-dr5s3vtOG8NkVSwa8CC55XBIKKwajomSZRb0RiMOOOF6TpqZBZvtbDjpzWICvdd/plDF6uOtaRfSgblPQLAioQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8757,12 +8757,12 @@
       }
     },
     "bpmn-js": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.6.3.tgz",
-      "integrity": "sha512-dNVZhzdxA6q9GFlc5UE691gBGSiGYjLcXbohQ65/P0ZUERgJi7z8Kgnu2f/rrizfE/jray+hAjMfZdFfOG/B+w==",
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.6.4.tgz",
+      "integrity": "sha512-8hvS+MD34ol1WYUqygY+OMDurD/pLt+ok7LC9lmQHqcQe21BDRXjDZpoNGZf/dwcth6Rec1zVAOhT8Um9Wk8FQ==",
       "dev": true,
       "requires": {
-        "bpmn-moddle": "^9.0.3",
+        "bpmn-moddle": "^9.0.4",
         "diagram-js": "^15.3.0",
         "diagram-js-direct-editing": "^3.2.0",
         "ids": "^1.0.5",
@@ -8773,9 +8773,9 @@
       }
     },
     "bpmn-moddle": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-9.0.3.tgz",
-      "integrity": "sha512-Mv9KKKSaH5PsN5b1j7GoLfsQ9Ortm5o9Rj7Xy9hnsOhUSUJWIvlch//qYPUvaE6CS4uR6dtujOPum7mLIhl6xQ==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-9.0.4.tgz",
+      "integrity": "sha512-dr5s3vtOG8NkVSwa8CC55XBIKKwajomSZRb0RiMOOOF6TpqZBZvtbDjpzWICvdd/plDF6uOtaRfSgblPQLAioQ==",
       "dev": true,
       "requires": {
         "min-dash": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/core": "^7.28.3",
     "babel-loader": "^10.0.0",
     "babel-plugin-istanbul": "^7.0.0",
-    "bpmn-js": "^18.6.3",
+    "bpmn-js": "^18.6.4",
     "camunda-bpmn-moddle": "^7.0.1",
     "chai": "^4.5.0",
     "cross-env": "^10.0.0",

--- a/test/camunda-cloud/CleanUpAdHocSubProcessBehaviorSpec.js
+++ b/test/camunda-cloud/CleanUpAdHocSubProcessBehaviorSpec.js
@@ -45,7 +45,9 @@ describe('camunda-cloud/features/modeling - CleanUpAdHocSubProcessBehavior', fun
       // then
       const bo = getBusinessObject(element);
       expect(bo.get('completionCondition')).to.not.exist;
-      expect(bo.get('cancelRemainingInstances')).not.to.exist;
+
+      // default is true
+      expect(bo.get('cancelRemainingInstances')).to.be.true;
 
       const adHoc = getAdHoc(element);
       expect(adHoc).to.exist;
@@ -63,7 +65,7 @@ describe('camunda-cloud/features/modeling - CleanUpAdHocSubProcessBehavior', fun
       // then
       const bo = getBusinessObject(element);
       expect(bo.get('completionCondition').get('body')).to.equal('=all(items, item.completed)');
-      expect(bo.get('cancelRemainingInstances')).to.be.true;
+      expect(bo.get('cancelRemainingInstances')).to.be.false;
 
       const adHoc = getAdHoc(element);
       expect(adHoc).to.exist;
@@ -82,7 +84,7 @@ describe('camunda-cloud/features/modeling - CleanUpAdHocSubProcessBehavior', fun
       // then
       const bo = getBusinessObject(element);
       expect(bo.get('completionCondition')).to.not.exist;
-      expect(bo.get('cancelRemainingInstances')).not.to.exist;
+      expect(bo.get('cancelRemainingInstances')).to.be.true;
 
       const adHoc = getAdHoc(element);
       expect(adHoc).to.exist;

--- a/test/camunda-cloud/process-adHocSubProcess.bpmn
+++ b/test/camunda-cloud/process-adHocSubProcess.bpmn
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_adhoc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.11.0">
   <bpmn:process id="Process_AdHoc" isExecutable="true">
-    <bpmn:adHocSubProcess id="AdHocSubProcess_1" name="AdHocSubProcess_1" cancelRemainingInstances="true">
+    <bpmn:adHocSubProcess id="AdHocSubProcess_1" name="AdHocSubProcess_1" cancelRemainingInstances="false">
       <bpmn:extensionElements>
         <zeebe:adHoc activeElementsCollection="=items" outputCollection="=results" outputElement="result" />
       </bpmn:extensionElements>


### PR DESCRIPTION
This PR adjusts the tests to the correct default value for `cancelRemainingInstance`. Run together with https://github.com/bpmn-io/bpmn-moddle/pull/132 to verify green tests.

In order to merge this, we need to release https://github.com/bpmn-io/bpmn-moddle/pull/132, then update `bpmn-js` and merge an update to this PR.