### PR TITLE
feat: add test for maintaining variableEvents property when label of …

### DIFF
--- a/lib/camunda-platform/RemoveVariableEventBehaviour.js
+++ b/lib/camunda-platform/RemoveVariableEventBehaviour.js
@@ -21,6 +21,11 @@ export default class RemoveVariableEventBehaviour extends CommandInterceptor {
         shape
       } = context;
 
+      // Ignore label shapes; only the actual BPMN element carries event definitions.
+      if (shape.labelTarget) {
+        return;
+      }
+
       const newParentBusinessObject = getBusinessObject(newParent),
             shapeBusinessObject = getBusinessObject(shape);
 

--- a/test/camunda-platform/RemoveVariableEventBehaviourSpec.js
+++ b/test/camunda-platform/RemoveVariableEventBehaviourSpec.js
@@ -75,6 +75,32 @@ describe('RemoveVariableEventBehaviour', function() {
     });
 
 
+    describe('when label of named conditional startEvent is moved within event subprocess', function() {
+
+      it('should maintain variableEvents property', inject(function(elementRegistry, modeling) {
+
+        // given
+        const startEvent = elementRegistry.get('startEvent_1'),
+              startBusinessObject = getBusinessObject(startEvent),
+              eventDefinitions = startBusinessObject.get('eventDefinitions');
+
+        // assume
+        eventDefinitions.forEach(def => {
+          expect(def.get('camunda:variableEvents')).to.not.be.undefined;
+        });
+
+        // when
+        modeling.moveShape(startEvent.label, { x: 10, y: 10 });
+
+        // then
+        eventDefinitions.forEach(eventDefinition => {
+          expect(eventDefinition.get('camunda:variableEvents')).to.not.be.undefined;
+        });
+      }));
+
+    });
+
+
     describe('when conditional startEvent with variableEvents property is created out of event subprocess', function() {
 
       it('should not have variableEvents property', inject(function(canvas, modeling, bpmnFactory) {


### PR DESCRIPTION
…conditional startEvent is moved within event subprocess

### Proposed Changes

- Relates https://github.com/camunda/camunda-modeler/issues/4495

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
