### PR TITLE
feat: add cleanup for `beforeAll` execution listeners when multi-instance is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [camunda-bpmn-js-behaviors](https://github.com/camunda/ca
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.15.0
+
+* `FEAT`: add cleanup for `beforeAll` execution listeners when multi-instance is removed ([#126](https://github.com/camunda/camunda-bpmn-js-behaviors/pull/126))
+
 ## 1.14.1
 
 * `FIX`: do not clear Variable Events on boundary events ([#120](https://github.com/camunda/camunda-bpmn-js-behaviors/pull/120))

--- a/lib/camunda-cloud/CleanUpExecutionListenersBehavior.js
+++ b/lib/camunda-cloud/CleanUpExecutionListenersBehavior.js
@@ -1,4 +1,4 @@
-import { is, isAny } from 'bpmn-js/lib/util/ModelUtil';
+import { getBusinessObject, is, isAny } from 'bpmn-js/lib/util/ModelUtil';
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 import { without } from 'min-dash';
 
@@ -25,6 +25,34 @@ export default class CleanUpExecutionListenersBehavior extends CommandIntercepto
 
       const listeners = executionListenersContainer.get('listeners');
       const newListeners = withoutDisallowedListeners(element, listeners);
+
+      if (newListeners.length !== listeners.length) {
+        modeling.updateModdleProperties(element, executionListenersContainer, { listeners: newListeners });
+      }
+    });
+
+    // remove `beforeAll` execution listeners when multi-instance is removed
+    this.postExecuted([
+      'element.updateProperties',
+      'element.updateModdleProperties'
+    ], function(event) {
+      const { element, properties } = event.context;
+
+      if (!('loopCharacteristics' in properties)) {
+        return;
+      }
+
+      if (isMultiInstance(element)) {
+        return;
+      }
+
+      const executionListenersContainer = getExecutionListenersContainer(element);
+      if (!executionListenersContainer) {
+        return;
+      }
+
+      const listeners = executionListenersContainer.get('listeners');
+      const newListeners = withoutBeforeAllListeners(listeners);
 
       if (newListeners.length !== listeners.length) {
         modeling.updateModdleProperties(element, executionListenersContainer, { listeners: newListeners });
@@ -62,6 +90,7 @@ CleanUpExecutionListenersBehavior.$inject = [
 function withoutDisallowedListeners(element, listeners) {
   listeners = withoutDisallowedStartListeners(element, listeners);
   listeners = withoutDisallowedEndListeners(element, listeners);
+  listeners = withoutDisallowedBeforeAllListeners(element, listeners);
 
   return listeners;
 }
@@ -82,6 +111,18 @@ function withoutDisallowedEndListeners(element, listeners) {
   return listeners;
 }
 
+function withoutDisallowedBeforeAllListeners(element, listeners) {
+  if (isMultiInstance(element)) {
+    return listeners;
+  }
+
+  return withoutBeforeAllListeners(listeners);
+}
+
+function withoutBeforeAllListeners(listeners) {
+  return listeners.filter(listener => listener.eventType !== 'beforeAll');
+}
+
 function shouldRemoveEndListeners(element) {
   if (
     is(element, 'bpmn:BoundaryEvent') && isCompensationEvent(element) ||
@@ -90,6 +131,11 @@ function shouldRemoveEndListeners(element) {
   ) {
     return true;
   }
+}
+
+function isMultiInstance(element) {
+  const loopCharacteristics = getBusinessObject(element).get('loopCharacteristics');
+  return !!loopCharacteristics && is(loopCharacteristics, 'bpmn:MultiInstanceLoopCharacteristics');
 }
 
 function isCompensationEvent(element) {

--- a/test/camunda-cloud/CleanUpExecutionListenersBehaviorSpec.js
+++ b/test/camunda-cloud/CleanUpExecutionListenersBehaviorSpec.js
@@ -314,6 +314,24 @@ describe('camunda-cloud/features/modeling - CleanUpExecutionListenersBehavior', 
         expect(listeners).to.have.lengthOf(3);
       })
     );
+
+
+    it('should NOT remove `beforeAll` when updating loopCharacteristics properties',
+      inject(function(elementRegistry, modeling) {
+
+        // given
+        const el = elementRegistry.get('MultiInstanceTask');
+        const bo = getBusinessObject(el);
+
+        // when
+        modeling.updateModdleProperties(el, bo.get('loopCharacteristics'), { isSequential: true });
+
+        // then
+        const listeners = getListeners(el);
+        expect(listeners).to.have.lengthOf(3);
+        expect(listeners.map(l => l.get('eventType'))).to.eql([ 'beforeAll', 'start', 'end' ]);
+      })
+    );
   });
 
 

--- a/test/camunda-cloud/CleanUpExecutionListenersBehaviorSpec.js
+++ b/test/camunda-cloud/CleanUpExecutionListenersBehaviorSpec.js
@@ -207,7 +207,138 @@ describe('camunda-cloud/features/modeling - CleanUpExecutionListenersBehavior', 
       expect(extensionElements.get('values')).to.have.lengthOf(1);
     }));
   });
+
+
+  describe('remove `beforeAll` listeners when multi-instance is removed', function() {
+
+    it('should remove `beforeAll` and keep `start` / `end`',
+      inject(function(elementRegistry, modeling) {
+
+        // given
+        const el = elementRegistry.get('MultiInstanceTask');
+
+        // when
+        modeling.updateProperties(el, { loopCharacteristics: undefined });
+
+        // then
+        const listeners = getListeners(el);
+        expect(listeners).to.have.lengthOf(2);
+        expect(listeners.map(l => l.get('eventType'))).to.eql([ 'start', 'end' ]);
+      })
+    );
+
+
+    it('should remove `beforeAll` when multi-instance is removed via `updateModdleProperties`',
+      inject(function(elementRegistry, modeling) {
+
+        // given
+        const el = elementRegistry.get('MultiInstanceTask');
+        const bo = getBusinessObject(el);
+
+        // when
+        modeling.updateModdleProperties(el, bo, { loopCharacteristics: undefined });
+
+        // then
+        const listeners = getListeners(el);
+        expect(listeners).to.have.lengthOf(2);
+        expect(listeners.map(l => l.get('eventType'))).to.eql([ 'start', 'end' ]);
+      })
+    );
+
+
+    it('should remove the listeners container when only `beforeAll` was present',
+      inject(function(elementRegistry, modeling) {
+
+        // given
+        const el = elementRegistry.get('MultiInstanceTask_OnlyBeforeAll');
+
+        // when
+        modeling.updateProperties(el, { loopCharacteristics: undefined });
+
+        // then
+        const container = getExecutionListenersContainer(el);
+        expect(container).not.to.exist;
+      })
+    );
+
+
+    it('should undo',
+      inject(function(elementRegistry, modeling, commandStack) {
+
+        // given
+        const el = elementRegistry.get('MultiInstanceTask');
+
+        // when
+        modeling.updateProperties(el, { loopCharacteristics: undefined });
+        commandStack.undo();
+
+        // then
+        const listeners = getListeners(el);
+        expect(listeners).to.have.lengthOf(3);
+        expect(listeners.map(l => l.get('eventType'))).to.eql([ 'beforeAll', 'start', 'end' ]);
+      })
+    );
+
+
+    it('should redo',
+      inject(function(elementRegistry, modeling, commandStack) {
+
+        // given
+        const el = elementRegistry.get('MultiInstanceTask');
+
+        // when
+        modeling.updateProperties(el, { loopCharacteristics: undefined });
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        const listeners = getListeners(el);
+        expect(listeners).to.have.lengthOf(2);
+        expect(listeners.map(l => l.get('eventType'))).to.eql([ 'start', 'end' ]);
+      })
+    );
+
+
+    it('should NOT remove `beforeAll` when new loopCharacteristics is also multi-instance',
+      inject(function(elementRegistry, modeling, bpmnFactory) {
+
+        // given
+        const el = elementRegistry.get('MultiInstanceTask');
+        const loopCharacteristics = bpmnFactory.create('bpmn:MultiInstanceLoopCharacteristics', { isSequential: true });
+
+        // when
+        modeling.updateProperties(el, { loopCharacteristics });
+
+        // then
+        const listeners = getListeners(el);
+        expect(listeners).to.have.lengthOf(3);
+      })
+    );
+  });
+
+
+  it('should keep `beforeAll` when MI task is replaced with another MI-capable type',
+    inject(function(bpmnReplace, elementRegistry) {
+
+      // given
+      const el = elementRegistry.get('MultiInstanceTask');
+
+      // when
+      bpmnReplace.replaceElement(el, { type: 'bpmn:UserTask' });
+
+      // then
+      const replaced = elementRegistry.get('MultiInstanceTask');
+      const listeners = getListeners(replaced);
+      expect(listeners).to.have.lengthOf(3);
+      expect(listeners.map(l => l.get('eventType'))).to.eql([ 'beforeAll', 'start', 'end' ]);
+    })
+  );
 });
+
+function getListeners(element) {
+  const container = getExecutionListenersContainer(element);
+  return (container && container.get('listeners')) || [];
+}
 
 function getExecutionListenersContainer(element) {
   return getExtensionElementsList(getBusinessObject(element), 'zeebe:ExecutionListeners')[0];

--- a/test/camunda-cloud/execution-listeners.bpmn
+++ b/test/camunda-cloud/execution-listeners.bpmn
@@ -82,6 +82,24 @@
       </bpmn:extensionElements>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0jqwplw" />
     </bpmn:boundaryEvent>
+    <bpmn:serviceTask id="MultiInstanceTask">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="beforeAll" retries="3" type="mi-body-init" />
+          <zeebe:executionListener eventType="start" retries="3" type="mi-entry-start" />
+          <zeebe:executionListener eventType="end" retries="3" type="mi-entry-end" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:multiInstanceLoopCharacteristics />
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="MultiInstanceTask_OnlyBeforeAll">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="beforeAll" retries="3" type="mi-body-init" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:multiInstanceLoopCharacteristics />
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
@@ -111,6 +129,12 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BoundaryEvent_di" bpmnElement="BoundaryEvent">
         <dc:Bounds x="492" y="692" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="MultiInstanceTask_di" bpmnElement="MultiInstanceTask">
+        <dc:Bounds x="580" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="MultiInstanceTask_OnlyBeforeAll_di" bpmnElement="MultiInstanceTask_OnlyBeforeAll">
+        <dc:Bounds x="720" y="400" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5869

### Proposed Changes

Add cleanup for `beforeAll` execution listeners when multi-instance is removed

Should be integrated in https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1215

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
