### PR TITLE
feat: add start event form cleanup on element delete, replace or move from the root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [camunda-bpmn-js-behaviors](https://github.com/camunda/ca
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: add start event from cleanup on element delete, replace, copy/paste or move from the root ([#127](https://github.com/camunda/camunda-bpmn-js-behaviors/pull/127))
+* `DEPS`: update to `zeebe-bpmn-moddle@1.14.0`
+
+
 ## 1.15.0
 
 * `FEAT`: add cleanup for `beforeAll` execution listeners when multi-instance is removed ([#126](https://github.com/camunda/camunda-bpmn-js-behaviors/pull/126))

--- a/lib/camunda-cloud/FormsBehavior.js
+++ b/lib/camunda-cloud/FormsBehavior.js
@@ -5,7 +5,7 @@ import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 import { createElement } from '../util/ElementUtil';
 import { getExtensionElementsList } from '../util/ExtensionElementsUtil';
 
-import { is } from 'bpmn-js/lib/util/ModelUtil';
+import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
   createUserTaskFormId,
@@ -43,8 +43,22 @@ export default class FormsBehavior extends CommandInterceptor {
       }
     }
 
+    function removeFormDefinition(element, formDefinition) {
+      const bo = getBusinessObject(element);
+      const extensionElements = bo.get('extensionElements');
+      const values = without(extensionElements.get('values'), formDefinition);
+
+      modeling.updateModdleProperties(element, extensionElements, { values });
+
+      if (!values.length) {
+        modeling.updateModdleProperties(element, bo, {
+          extensionElements: undefined
+        });
+      }
+    }
+
     /**
-     * Remove zeebe:UserTaskForm on user task removed.
+     * Remove zeebe:UserTaskForm on user task or start event removed.
      */
     this.postExecute('shape.delete', function(context) {
       const {
@@ -56,12 +70,77 @@ export default class FormsBehavior extends CommandInterceptor {
 
       const userTaskForm = getUserTaskForm(shape, { rootElement });
 
-      if (!is(shape, 'bpmn:UserTask') || !userTaskForm) {
+      if ((!is(shape, 'bpmn:UserTask') && !is(shape, 'bpmn:StartEvent')) || !userTaskForm) {
         return;
       }
 
       removeUserTaskForm(shape, rootElement, userTaskForm);
     }, true);
+
+
+    /**
+     * Clean up form definition when a start event is moved from the root
+     * process into a subprocess (forms are only supported on root-level
+     * none start events).
+     */
+    this.postExecuted('shape.move', function(event) {
+      const { context } = event;
+      const { shape, newParent } = context;
+
+      if (!is(shape, 'bpmn:StartEvent')) {
+        return;
+      }
+
+      // Only clean up if moved into a subprocess
+      if (!is(newParent, 'bpmn:SubProcess')) {
+        return;
+      }
+
+      const formDefinition = getFormDefinition(shape);
+
+      if (!formDefinition) {
+        return;
+      }
+
+      const userTaskForm = getUserTaskForm(shape);
+
+      // Clean up embedded form if present
+      if (userTaskForm) {
+        removeUserTaskForm(shape, getRootElement(shape), userTaskForm);
+      }
+
+      removeFormDefinition(shape, formDefinition);
+    });
+
+
+    /**
+     * Clean up form definition when a none start event is replaced with
+     * a typed start event (message, timer, signal, etc.).
+     */
+    this.postExecuted('shape.replace', function(event) {
+      const { context } = event;
+      const { newShape } = context;
+
+      if (!is(newShape, 'bpmn:StartEvent')) {
+        return;
+      }
+
+      const bo = getBusinessObject(newShape);
+      const eventDefinitions = bo.get('eventDefinitions');
+
+      // Only clean up if the new shape has event definitions (not a none start event)
+      if (!eventDefinitions || !eventDefinitions.length) {
+        return;
+      }
+
+      const formDefinition = getFormDefinition(newShape);
+
+      if (!formDefinition) {
+        return;
+      }
+
+      removeFormDefinition(newShape, formDefinition);
+    });
 
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "sinon": "^21.0.0",
         "sinon-chai": "^4.0.0",
         "webpack": "^5.101.2",
-        "zeebe-bpmn-moddle": "^1.12.0"
+        "zeebe-bpmn-moddle": "^1.14.0"
       },
       "peerDependencies": {
         "bpmn-js": ">= 9",
@@ -7697,9 +7697,9 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.12.0.tgz",
-      "integrity": "sha512-wYKfgdV5suCNx4IVaq0qOjHRxSQ5XOkxfwC8EBHuGCtmEVk8zv1VRg0opV0kVQe89jvRH3iF3Yl/DoB6qiCV5Q==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.14.0.tgz",
+      "integrity": "sha512-jhEr/UOaWcT4peXxkUqXd7tscjYf2evbm/ElofmZ8TFPqs8MhxTVolFQBtKza6n9cwIVDyc6L7ChQHSzicG7QA==",
       "dev": true,
       "license": "MIT"
     },
@@ -13174,9 +13174,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.12.0.tgz",
-      "integrity": "sha512-wYKfgdV5suCNx4IVaq0qOjHRxSQ5XOkxfwC8EBHuGCtmEVk8zv1VRg0opV0kVQe89jvRH3iF3Yl/DoB6qiCV5Q==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.14.0.tgz",
+      "integrity": "sha512-jhEr/UOaWcT4peXxkUqXd7tscjYf2evbm/ElofmZ8TFPqs8MhxTVolFQBtKza6n9cwIVDyc6L7ChQHSzicG7QA==",
       "dev": true
     },
     "zod": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "sinon": "^21.0.0",
     "sinon-chai": "^4.0.0",
     "webpack": "^5.101.2",
-    "zeebe-bpmn-moddle": "^1.12.0"
+    "zeebe-bpmn-moddle": "^1.14.0"
   },
   "peerDependencies": {
     "bpmn-js": ">= 9",

--- a/test/camunda-cloud/CopyPasteBehaviorSpec.js
+++ b/test/camunda-cloud/CopyPasteBehaviorSpec.js
@@ -1006,6 +1006,61 @@ describe('CopyPasteBehavior', function() {
 
   });
 
+
+  describe('zeebe:FormDefinition', function() {
+
+    it('should allow on bpmn:StartEvent', function() {
+
+      // given
+      const formDefinition = moddle.create('zeebe:FormDefinition'),
+            startEvent = moddle.create('bpmn:StartEvent'),
+            extensionElements = moddle.create('bpmn:ExtensionElements');
+
+      extensionElements.$parent = startEvent;
+
+      // when
+      const canCopyProperty = copyPasteBehavior.canCopyProperty(formDefinition, extensionElements);
+
+      // then
+      expect(canCopyProperty).not.to.be.false;
+    });
+
+
+    it('should allow on bpmn:UserTask', function() {
+
+      // given
+      const formDefinition = moddle.create('zeebe:FormDefinition'),
+            userTask = moddle.create('bpmn:UserTask'),
+            extensionElements = moddle.create('bpmn:ExtensionElements');
+
+      extensionElements.$parent = userTask;
+
+      // when
+      const canCopyProperty = copyPasteBehavior.canCopyProperty(formDefinition, extensionElements);
+
+      // then
+      expect(canCopyProperty).not.to.be.false;
+    });
+
+
+    it('should not allow on bpmn:ServiceTask', function() {
+
+      // given
+      const formDefinition = moddle.create('zeebe:FormDefinition'),
+            serviceTask = moddle.create('bpmn:ServiceTask'),
+            extensionElements = moddle.create('bpmn:ExtensionElements');
+
+      extensionElements.$parent = serviceTask;
+
+      // when
+      const canCopyProperty = copyPasteBehavior.canCopyProperty(formDefinition, extensionElements);
+
+      // then
+      expect(canCopyProperty).to.be.false;
+    });
+
+  });
+
 });
 
 

--- a/test/camunda-cloud/StartEventFormsBehaviorSpec.js
+++ b/test/camunda-cloud/StartEventFormsBehaviorSpec.js
@@ -1,0 +1,328 @@
+import { expect } from 'chai';
+
+import {
+  bootstrapCamundaCloudModeler,
+  inject
+} from 'test/TestHelper';
+
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import { getExtensionElementsList } from 'lib/util/ExtensionElementsUtil';
+
+import {
+  getFormDefinition,
+} from 'lib/camunda-cloud/util/FormsUtil';
+
+import diagramXML from './process-start-event-forms.bpmn';
+
+
+describe('camunda-cloud/features/modeling - FormsBehavior - start events', function() {
+
+  beforeEach(bootstrapCamundaCloudModeler(diagramXML));
+
+
+  describe('remove start event', function() {
+
+    describe('with linked form', function() {
+
+      it('should remove form definition', inject(
+        function(elementRegistry, modeling) {
+
+          // given
+          const element = elementRegistry.get('StartEvent_Linked');
+
+          // when
+          modeling.removeElements([ element ]);
+
+          // then
+          expect(elementRegistry.get('StartEvent_Linked')).not.to.exist;
+        }
+      ));
+
+
+      it('should undo', inject(
+        function(commandStack, elementRegistry, modeling) {
+
+          // given
+          const element = elementRegistry.get('StartEvent_Linked');
+
+          modeling.removeElements([ element ]);
+
+          // when
+          commandStack.undo();
+
+          // then
+          const restoredElement = elementRegistry.get('StartEvent_Linked');
+          const formDefinition = getFormDefinition(restoredElement);
+
+          expect(formDefinition).to.exist;
+          expect(formDefinition.get('formId')).to.equal('myFormId');
+        }
+      ));
+
+    });
+
+    describe('with embedded form', function() {
+
+      it('should remove user task form from root', inject(
+        function(canvas, elementRegistry, modeling) {
+
+          // given
+          const rootElement = canvas.getRootElement();
+          const element = elementRegistry.get('StartEvent_Embedded');
+
+          // when
+          modeling.removeElements([ element ]);
+
+          // then
+          const userTaskForms = getExtensionElementsList(
+            getBusinessObject(rootElement), 'zeebe:UserTaskForm'
+          );
+
+          expect(userTaskForms).to.have.lengthOf(0);
+        }
+      ));
+
+
+      it('should undo', inject(
+        function(canvas, commandStack, elementRegistry, modeling) {
+
+          // given
+          const rootElement = canvas.getRootElement();
+          const element = elementRegistry.get('StartEvent_Embedded');
+
+          modeling.removeElements([ element ]);
+
+          // when
+          commandStack.undo();
+
+          // then
+          const userTaskForms = getExtensionElementsList(
+            getBusinessObject(rootElement), 'zeebe:UserTaskForm'
+          );
+
+          expect(userTaskForms).to.have.lengthOf(1);
+        }
+      ));
+
+    });
+
+  });
+
+
+  describe('replace start event', function() {
+
+    describe('with linked form', function() {
+
+      it('should remove form definition when replaced with message start event', inject(
+        function(bpmnReplace, elementRegistry) {
+
+          // given
+          const element = elementRegistry.get('StartEvent_Linked');
+
+          // when
+          const newElement = bpmnReplace.replaceElement(element, {
+            type: 'bpmn:StartEvent',
+            eventDefinitionType: 'bpmn:MessageEventDefinition'
+          });
+
+          // then
+          const formDefinition = getFormDefinition(newElement);
+
+          expect(formDefinition).to.not.exist;
+        }
+      ));
+
+
+      it('should undo', inject(
+        function(bpmnReplace, commandStack, elementRegistry) {
+
+          // given
+          const element = elementRegistry.get('StartEvent_Linked');
+
+          bpmnReplace.replaceElement(element, {
+            type: 'bpmn:StartEvent',
+            eventDefinitionType: 'bpmn:MessageEventDefinition'
+          });
+
+          // when
+          commandStack.undo();
+
+          // then
+          const restoredElement = elementRegistry.get('StartEvent_Linked');
+          const formDefinition = getFormDefinition(restoredElement);
+
+          expect(formDefinition).to.exist;
+          expect(formDefinition.get('formId')).to.equal('myFormId');
+        }
+      ));
+
+    });
+
+
+    describe('with embedded form', function() {
+
+      it('should remove form definition and user task form when replaced with timer start event', inject(
+        function(bpmnReplace, canvas, elementRegistry) {
+
+          // given
+          const rootElement = canvas.getRootElement();
+          const element = elementRegistry.get('StartEvent_Embedded');
+
+          // when
+          const newElement = bpmnReplace.replaceElement(element, {
+            type: 'bpmn:StartEvent',
+            eventDefinitionType: 'bpmn:TimerEventDefinition'
+          });
+
+          // then
+          const formDefinition = getFormDefinition(newElement);
+
+          expect(formDefinition).to.not.exist;
+
+          const userTaskForms = getExtensionElementsList(
+            getBusinessObject(rootElement), 'zeebe:UserTaskForm'
+          );
+
+          expect(userTaskForms).to.have.lengthOf(0);
+        }
+      ));
+
+
+      it('should undo', inject(
+        function(bpmnReplace, canvas, commandStack, elementRegistry) {
+
+          // given
+          const rootElement = canvas.getRootElement();
+          const element = elementRegistry.get('StartEvent_Embedded');
+
+          bpmnReplace.replaceElement(element, {
+            type: 'bpmn:StartEvent',
+            eventDefinitionType: 'bpmn:TimerEventDefinition'
+          });
+
+          // when
+          commandStack.undo();
+
+          // then
+          const restoredElement = elementRegistry.get('StartEvent_Embedded');
+          const formDefinition = getFormDefinition(restoredElement);
+
+          expect(formDefinition).to.exist;
+
+          const userTaskForms = getExtensionElementsList(
+            getBusinessObject(rootElement), 'zeebe:UserTaskForm'
+          );
+
+          expect(userTaskForms).to.have.lengthOf(1);
+        }
+      ));
+
+    });
+
+  });
+
+
+  describe('move start event to subprocess', function() {
+
+    describe('with linked form', function() {
+
+      it('should remove form definition', inject(
+        function(elementRegistry, modeling) {
+
+          // given
+          const element = elementRegistry.get('StartEvent_Linked');
+          const subProcess = elementRegistry.get('SubProcess_1');
+
+          // when
+          modeling.moveElements([ element ], { x: 0, y: 0 }, subProcess);
+
+          // then
+          const formDefinition = getFormDefinition(element);
+
+          expect(formDefinition).not.to.exist;
+        }
+      ));
+
+
+      it('should undo', inject(
+        function(commandStack, elementRegistry, modeling) {
+
+          // given
+          const element = elementRegistry.get('StartEvent_Linked');
+          const subProcess = elementRegistry.get('SubProcess_1');
+
+          modeling.moveElements([ element ], { x: 0, y: 0 }, subProcess);
+
+          // when
+          commandStack.undo();
+
+          // then
+          const formDefinition = getFormDefinition(element);
+
+          expect(formDefinition).to.exist;
+          expect(formDefinition.get('formId')).to.equal('myFormId');
+        }
+      ));
+
+    });
+
+
+    describe('with embedded form', function() {
+
+      it('should remove form definition and user task form', inject(
+        function(canvas, elementRegistry, modeling) {
+
+          // given
+          const rootElement = canvas.getRootElement();
+          const element = elementRegistry.get('StartEvent_Embedded');
+          const subProcess = elementRegistry.get('SubProcess_1');
+
+          // when
+          modeling.moveElements([ element ], { x: 0, y: 0 }, subProcess);
+
+          // then
+          const formDefinition = getFormDefinition(element);
+
+          expect(formDefinition).not.to.exist;
+
+          const userTaskForms = getExtensionElementsList(
+            getBusinessObject(rootElement), 'zeebe:UserTaskForm'
+          );
+
+          expect(userTaskForms).to.have.lengthOf(0);
+        }
+      ));
+
+
+      it('should undo', inject(
+        function(canvas, commandStack, elementRegistry, modeling) {
+
+          // given
+          const rootElement = canvas.getRootElement();
+          const element = elementRegistry.get('StartEvent_Embedded');
+          const subProcess = elementRegistry.get('SubProcess_1');
+
+          modeling.moveElements([ element ], { x: 0, y: 0 }, subProcess);
+
+          // when
+          commandStack.undo();
+
+          // then
+          const formDefinition = getFormDefinition(element);
+
+          expect(formDefinition).to.exist;
+
+          const userTaskForms = getExtensionElementsList(
+            getBusinessObject(rootElement), 'zeebe:UserTaskForm'
+          );
+
+          expect(userTaskForms).to.have.lengthOf(1);
+        }
+      ));
+
+    });
+
+  });
+
+});

--- a/test/camunda-cloud/process-start-event-forms.bpmn
+++ b/test/camunda-cloud/process-start-event-forms.bpmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:userTaskForm id="UserTaskForm_1">{}</zeebe:userTaskForm>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_Linked" name="Linked form">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="myFormId" />
+      </bpmn:extensionElements>
+    </bpmn:startEvent>
+    <bpmn:startEvent id="StartEvent_Embedded" name="Embedded form">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="camunda-forms:bpmn:UserTaskForm_1" />
+      </bpmn:extensionElements>
+    </bpmn:startEvent>
+    <bpmn:startEvent id="StartEvent_NoForm" name="No form" />
+    <bpmn:subProcess id="SubProcess_1" name="Sub Process" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="StartEvent_Linked_di" bpmnElement="StartEvent_Linked">
+        <dc:Bounds x="160" y="80" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_Embedded_di" bpmnElement="StartEvent_Embedded">
+        <dc:Bounds x="220" y="80" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_NoForm_di" bpmnElement="StartEvent_NoForm">
+        <dc:Bounds x="280" y="80" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_1_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="350" y="60" width="200" height="120" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4672

### Proposed Changes

Add start event linked or embeded (`zeebe:UserTaskForm`) from cleanup on element delete, replace, copy/paste or move from the root

This changes would be further integrated to https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1219

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
