### PR TITLE
fix: fix start event form behavior with copy/paste

### DIFF
--- a/lib/camunda-cloud/FormsBehavior.js
+++ b/lib/camunda-cloud/FormsBehavior.js
@@ -62,9 +62,14 @@ export default class FormsBehavior extends CommandInterceptor {
      */
     this.postExecute('shape.delete', function(context) {
       const {
+        labelTarget,
         oldParent,
         shape
       } = context;
+
+      if (labelTarget) {
+        return;
+      }
 
       const rootElement = getRootElement(oldParent);
 
@@ -79,20 +84,19 @@ export default class FormsBehavior extends CommandInterceptor {
 
 
     /**
-     * Clean up form definition when a start event is moved from the root
-     * process into a subprocess (forms are only supported on root-level
-     * none start events).
+     * Clean up form definition when a start event is moved or pasted into
+     * a subprocess (forms are only supported on root-level none start events).
      */
-    this.postExecuted('shape.move', function(event) {
+    this.postExecuted([ 'shape.move', 'shape.create' ], function(event) {
       const { context } = event;
-      const { shape, newParent } = context;
+      const { shape } = context;
+      const parent = context.newParent || context.parent;
 
-      if (!is(shape, 'bpmn:StartEvent')) {
+      if (shape.labelTarget) {
         return;
       }
 
-      // Only clean up if moved into a subprocess
-      if (!is(newParent, 'bpmn:SubProcess')) {
+      if (!is(shape, 'bpmn:StartEvent') || !is(parent, 'bpmn:SubProcess')) {
         return;
       }
 
@@ -100,13 +104,6 @@ export default class FormsBehavior extends CommandInterceptor {
 
       if (!formDefinition) {
         return;
-      }
-
-      const userTaskForm = getUserTaskForm(shape);
-
-      // Clean up embedded form if present
-      if (userTaskForm) {
-        removeUserTaskForm(shape, getRootElement(shape), userTaskForm);
       }
 
       removeFormDefinition(shape, formDefinition);
@@ -144,14 +141,18 @@ export default class FormsBehavior extends CommandInterceptor {
 
 
     /**
-     * Create and reference new zeebe:UserTaskForm when user task is created
-     * that references existing zeebe:UserTaskForm that is already referenced by
-     * existing user task.
+     * Create and reference new zeebe:UserTaskForm when user task or start event
+     * is created that references existing zeebe:UserTaskForm that is already
+     * referenced by existing element.
      */
     this.postExecute('shape.create', function(context) {
       const { shape } = context;
 
-      if (!is(shape, 'bpmn:UserTask')) {
+      if (shape.labelTarget) {
+        return;
+      }
+
+      if (!is(shape, 'bpmn:UserTask') && !is(shape, 'bpmn:StartEvent')) {
         return;
       }
 

--- a/test/camunda-cloud/StartEventFormsBehaviorSpec.js
+++ b/test/camunda-cloud/StartEventFormsBehaviorSpec.js
@@ -11,6 +11,7 @@ import { getExtensionElementsList } from 'lib/util/ExtensionElementsUtil';
 
 import {
   getFormDefinition,
+  getUserTaskForm,
 } from 'lib/camunda-cloud/util/FormsUtil';
 
 import diagramXML from './process-start-event-forms.bpmn';
@@ -106,6 +107,31 @@ describe('camunda-cloud/features/modeling - FormsBehavior - start events', funct
       ));
 
     });
+
+  });
+
+
+  describe('remove start event label', function() {
+
+    it('should not remove user task form when label is deleted', inject(
+      function(canvas, elementRegistry, modeling) {
+
+        // given
+        const rootElement = canvas.getRootElement();
+        const element = elementRegistry.get('StartEvent_Embedded');
+        const label = element.label;
+
+        // when
+        modeling.removeElements([ label ]);
+
+        // then
+        const userTaskForms = getExtensionElementsList(
+          getBusinessObject(rootElement), 'zeebe:UserTaskForm'
+        );
+
+        expect(userTaskForms).to.have.lengthOf(1);
+      }
+    ));
 
   });
 
@@ -312,6 +338,134 @@ describe('camunda-cloud/features/modeling - FormsBehavior - start events', funct
           const formDefinition = getFormDefinition(element);
 
           expect(formDefinition).to.exist;
+
+          const userTaskForms = getExtensionElementsList(
+            getBusinessObject(rootElement), 'zeebe:UserTaskForm'
+          );
+
+          expect(userTaskForms).to.have.lengthOf(1);
+        }
+      ));
+
+    });
+
+  });
+
+
+  describe('paste start event at process root', function() {
+
+    describe('with linked form', function() {
+
+      it('should keep form definition', inject(
+        function(canvas, elementRegistry, copyPaste) {
+
+          // given
+          const rootElement = canvas.getRootElement();
+
+          // when
+          copyPaste.copy(elementRegistry.get('StartEvent_Linked'));
+
+          const pastedElement = copyPaste.paste({
+            element: rootElement,
+            point: { x: 200, y: 200 }
+          })[ 0 ];
+
+          // then
+          const formDefinition = getFormDefinition(pastedElement);
+
+          expect(formDefinition).to.exist;
+          expect(formDefinition.get('formId')).to.equal('myFormId');
+        }
+      ));
+
+    });
+
+
+    describe('with embedded form', function() {
+
+      it('should keep form definition and create new user task form reference', inject(
+        function(canvas, elementRegistry, copyPaste) {
+
+          // given
+          const rootElement = canvas.getRootElement();
+
+          // when
+          copyPaste.copy(elementRegistry.get('StartEvent_Embedded'));
+
+          const pastedElement = copyPaste.paste({
+            element: rootElement,
+            point: { x: 200, y: 200 }
+          })[ 0 ];
+
+          // then
+          const formDefinition = getFormDefinition(pastedElement);
+
+          expect(formDefinition).to.exist;
+
+          const userTaskForm = getUserTaskForm(pastedElement);
+
+          expect(userTaskForm).to.exist;
+          expect(userTaskForm.get('id')).to.not.equal('UserTaskForm_1');
+
+          const userTaskForms = getExtensionElementsList(
+            getBusinessObject(rootElement), 'zeebe:UserTaskForm'
+          );
+
+          expect(userTaskForms).to.have.lengthOf(2);
+        }
+      ));
+
+    });
+
+  });
+
+
+  describe('paste start event into subprocess', function() {
+
+    describe('with linked form', function() {
+
+      it('should remove form definition', inject(
+        function(elementRegistry, copyPaste) {
+
+          // given
+          const startEvent = elementRegistry.get('StartEvent_Linked');
+          const subProcess = elementRegistry.get('SubProcess_1');
+
+          // when
+          copyPaste.copy(startEvent);
+
+          const pastedElement = copyPaste.paste({
+            element: subProcess,
+            point: { x: 100, y: 100 }
+          })[ 0 ];
+
+          // then
+          expect(getFormDefinition(pastedElement)).not.to.exist;
+        }
+      ));
+
+    });
+
+
+    describe('with embedded form', function() {
+
+      it('should remove form definition and user task form', inject(
+        function(canvas, elementRegistry, copyPaste) {
+
+          // given
+          const rootElement = canvas.getRootElement();
+          const subProcess = elementRegistry.get('SubProcess_1');
+
+          // when
+          copyPaste.copy(elementRegistry.get('StartEvent_Embedded'));
+
+          const pastedElement = copyPaste.paste({
+            element: subProcess,
+            point: { x: 100, y: 100 }
+          })[ 0 ];
+
+          // then
+          expect(getFormDefinition(pastedElement)).not.to.exist;
 
           const userTaskForms = getExtensionElementsList(
             getBusinessObject(rootElement), 'zeebe:UserTaskForm'

--- a/test/camunda-cloud/process-start-event-forms.bpmn
+++ b/test/camunda-cloud/process-start-event-forms.bpmn
@@ -21,9 +21,15 @@
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="StartEvent_Linked_di" bpmnElement="StartEvent_Linked">
         <dc:Bounds x="160" y="80" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="148" y="123" width="61" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="StartEvent_Embedded_di" bpmnElement="StartEvent_Embedded">
         <dc:Bounds x="220" y="80" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="199" y="123" width="79" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="StartEvent_NoForm_di" bpmnElement="StartEvent_NoForm">
         <dc:Bounds x="280" y="80" width="36" height="36" />


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4672

### Proposed Changes

Addressed issues found during code review in https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1219#pullrequestreview-4337957048 

Fixed the form definition and user task form cleanup when paste start event into the subprocess. 
Create new user form reference when copy/paste start event with embedded form.


https://github.com/user-attachments/assets/57e0c4a2-0422-4bb9-b059-acd35816c50a

**Try it out:**
`npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel#start-event-form -l camunda/camunda-bpmn-js-behaviors#fix-start-event-form-cleanup`
 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [x] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
