### PR TITLE
feat: default script task to FEEL expression, business rule task to DMN decision

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -14,10 +14,8 @@ var suite = coverage ? 'test/coverage.js' : 'test/suite.js';
 // any of [ 'ChromeHeadless', 'Chrome', 'Firefox', 'Safari' ]
 var browsers = (process.env.TEST_BROWSERS || 'ChromeHeadless').split(',');
 
-module.exports = async function(karma) {
+module.exports = function(karma) {
 
-  // use puppeteer provided Chrome for testing
-  process.env.CHROME_BIN = await require('puppeteer').executablePath();
   var config = {
 
     basePath,

--- a/lib/camunda-cloud/CreateZeebeBusinessRuleTaskBehavior.js
+++ b/lib/camunda-cloud/CreateZeebeBusinessRuleTaskBehavior.js
@@ -1,0 +1,83 @@
+import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+import { createElement } from '../util/ElementUtil';
+import { getExtensionElementsList } from '../util/ExtensionElementsUtil';
+
+const HIGH_PRIORITY = 5000;
+
+/**
+ * Zeebe BPMN specific behavior for creating business rule tasks.
+ */
+export default class CreateZeebeBusinessRuleTaskBehavior extends CommandInterceptor {
+  constructor(bpmnFactory, eventBus, modeling) {
+    super(eventBus);
+
+    /**
+     * Add zeebe:CalledDecision extension element when creating bpmn:BusinessRuleTask,
+     * defaulting to the DMN decision implementation.
+     */
+    this.postExecuted(
+      [ 'shape.create', 'shape.replace' ],
+      HIGH_PRIORITY,
+      function(context) {
+        const shape = context.shape || context.newShape;
+        const explicitlyDisabled = context.hints && context.hints.createElementsBehavior === false;
+
+        if (!is(shape, 'bpmn:BusinessRuleTask') || explicitlyDisabled) {
+          return;
+        }
+
+        // Skip if any implementation is already set.
+        if (getCalledDecision(shape) || getTaskDefinition(shape)) {
+          return;
+        }
+
+        const businessObject = getBusinessObject(shape);
+        let extensionElements = businessObject.get('extensionElements');
+
+        if (!extensionElements) {
+          extensionElements = createElement(
+            'bpmn:ExtensionElements',
+            {
+              values: [],
+            },
+            businessObject,
+            bpmnFactory
+          );
+
+          modeling.updateProperties(shape, { extensionElements });
+        }
+
+        const calledDecision = createElement(
+          'zeebe:CalledDecision',
+          {},
+          extensionElements,
+          bpmnFactory
+        );
+
+        modeling.updateModdleProperties(shape, extensionElements, {
+          values: [ ...(extensionElements.values || []), calledDecision ],
+        });
+      },
+      true
+    );
+  }
+}
+
+CreateZeebeBusinessRuleTaskBehavior.$inject = [ 'bpmnFactory', 'eventBus', 'modeling' ];
+
+
+// helpers //////////
+
+function getCalledDecision(element) {
+  const businessObject = getBusinessObject(element);
+
+  return getExtensionElementsList(businessObject, 'zeebe:CalledDecision')[0] || null;
+}
+
+function getTaskDefinition(element) {
+  const businessObject = getBusinessObject(element);
+
+  return getExtensionElementsList(businessObject, 'zeebe:TaskDefinition')[0] || null;
+}

--- a/lib/camunda-cloud/CreateZeebeScriptTaskBehavior.js
+++ b/lib/camunda-cloud/CreateZeebeScriptTaskBehavior.js
@@ -1,0 +1,83 @@
+import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+import { createElement } from '../util/ElementUtil';
+import { getExtensionElementsList } from '../util/ExtensionElementsUtil';
+
+const HIGH_PRIORITY = 5000;
+
+/**
+ * Zeebe BPMN specific behavior for creating script tasks.
+ */
+export default class CreateZeebeScriptTaskBehavior extends CommandInterceptor {
+  constructor(bpmnFactory, eventBus, modeling) {
+    super(eventBus);
+
+    /**
+     * Add zeebe:Script extension element when creating bpmn:ScriptTask,
+     * defaulting to the FEEL expression implementation.
+     */
+    this.postExecuted(
+      [ 'shape.create', 'shape.replace' ],
+      HIGH_PRIORITY,
+      function(context) {
+        const shape = context.shape || context.newShape;
+        const explicitlyDisabled = context.hints && context.hints.createElementsBehavior === false;
+
+        if (!is(shape, 'bpmn:ScriptTask') || explicitlyDisabled) {
+          return;
+        }
+
+        // Skip if any implementation is already set.
+        if (getScript(shape) || getTaskDefinition(shape)) {
+          return;
+        }
+
+        const businessObject = getBusinessObject(shape);
+        let extensionElements = businessObject.get('extensionElements');
+
+        if (!extensionElements) {
+          extensionElements = createElement(
+            'bpmn:ExtensionElements',
+            {
+              values: [],
+            },
+            businessObject,
+            bpmnFactory
+          );
+
+          modeling.updateProperties(shape, { extensionElements });
+        }
+
+        const script = createElement(
+          'zeebe:Script',
+          {},
+          extensionElements,
+          bpmnFactory
+        );
+
+        modeling.updateModdleProperties(shape, extensionElements, {
+          values: [ ...(extensionElements.values || []), script ],
+        });
+      },
+      true
+    );
+  }
+}
+
+CreateZeebeScriptTaskBehavior.$inject = [ 'bpmnFactory', 'eventBus', 'modeling' ];
+
+
+// helpers //////////
+
+function getScript(element) {
+  const businessObject = getBusinessObject(element);
+
+  return getExtensionElementsList(businessObject, 'zeebe:Script')[0] || null;
+}
+
+function getTaskDefinition(element) {
+  const businessObject = getBusinessObject(element);
+
+  return getExtensionElementsList(businessObject, 'zeebe:TaskDefinition')[0] || null;
+}

--- a/lib/camunda-cloud/index.js
+++ b/lib/camunda-cloud/index.js
@@ -9,7 +9,9 @@ import CleanUpTaskListenersBehavior from './CleanUpTaskListenersBehavior';
 import CleanUpSubscriptionBehavior from './CleanUpSubscriptionBehavior';
 import CleanUpTimerExpressionBehavior from './CleanUpTimerExpressionBehavior';
 import CopyPasteBehavior from './CopyPasteBehavior';
+import CreateZeebeBusinessRuleTaskBehavior from './CreateZeebeBusinessRuleTaskBehavior';
 import CreateZeebeCallActivityBehavior from './CreateZeebeCallActivityBehavior';
+import CreateZeebeScriptTaskBehavior from './CreateZeebeScriptTaskBehavior';
 import CreateZeebeUserTaskBehavior from './CreateZeebeUserTaskBehavior';
 import DeleteParticipantBehaviour from '../shared/DeleteParticipantBehaviour';
 import FormsBehavior from './FormsBehavior';
@@ -32,7 +34,9 @@ export default {
     'cleanUpSubscriptionBehavior',
     'cleanUpTimerExpressionBehavior',
     'copyPasteBehavior',
+    'createZeebeBusinessRuleTaskBehavior',
     'createZeebeCallActivityBehavior',
+    'createZeebeScriptTaskBehavior',
     'createZeebeUserTaskBehavior',
     'deleteParticipantBehaviour',
     'formsBehavior',
@@ -52,7 +56,9 @@ export default {
   cleanUpSubscriptionBehavior: [ 'type', CleanUpSubscriptionBehavior ],
   cleanUpTimerExpressionBehavior: [ 'type', CleanUpTimerExpressionBehavior ],
   copyPasteBehavior: [ 'type', CopyPasteBehavior ],
+  createZeebeBusinessRuleTaskBehavior: [ 'type', CreateZeebeBusinessRuleTaskBehavior ],
   createZeebeCallActivityBehavior: [ 'type', CreateZeebeCallActivityBehavior ],
+  createZeebeScriptTaskBehavior: [ 'type', CreateZeebeScriptTaskBehavior ],
   createZeebeUserTaskBehavior: [ 'type', CreateZeebeUserTaskBehavior ],
   deleteParticipantBehaviour: [ 'type', DeleteParticipantBehaviour ],
   formsBehavior: [ 'type', FormsBehavior ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "mocha": "^11.0.0",
         "mocha-test-container-support": "^0.2.0",
         "npm-run-all2": "^9.0.0",
-        "puppeteer": "^25.0.0",
         "sinon": "^22.0.0",
         "sinon-chai": "^4.0.0",
         "webpack": "^5.101.2",
@@ -812,109 +811,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@puppeteer/browsers": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.3.tgz",
-      "integrity": "sha512-v3YaiGpzUTgOZkHBFR0iZg58Vto25SqBQxfLUXDiofJccwVl6Mlr7BdLCS1NZgxikdeIHf936cxYWL9IZp3tow==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.4.3",
-        "progress": "^2.0.3",
-        "semver": "^7.7.4",
-        "tar-fs": "^3.1.1",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/main-cli.js"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      },
-      "peerDependencies": {
-        "proxy-agent": ">=8.0.1"
-      },
-      "peerDependenciesMeta": {
-        "proxy-agent": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
-    "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -1476,20 +1372,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/b4a": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "dev": true,
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/babel-loader": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.0.0.tgz",
@@ -1559,97 +1441,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "node_modules/bare-events": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
-      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
-      "dev": true,
-      "peerDependencies": {
-        "bare-abort-controller": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-fs": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
-      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
-      "dev": true,
-      "dependencies": {
-        "bare-events": "^2.5.4",
-        "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4",
-        "bare-url": "^2.2.2",
-        "fast-fifo": "^1.3.2"
-      },
-      "engines": {
-        "bare": ">=1.16.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-os": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
-      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
-      "dev": true,
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
-    "node_modules/bare-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-      "dev": true,
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
-    },
-    "node_modules/bare-stream": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
-      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
-      "dev": true,
-      "dependencies": {
-        "streamx": "^2.25.0",
-        "teex": "^1.0.1"
-      },
-      "peerDependencies": {
-        "bare-abort-controller": "*",
-        "bare-buffer": "*",
-        "bare-events": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        },
-        "bare-buffer": {
-          "optional": true
-        },
-        "bare-events": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-url": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
-      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
-      "dev": true,
-      "dependencies": {
-        "bare-path": "^3.0.0"
-      }
     },
     "node_modules/base64id": {
       "version": "2.0.0",
@@ -2019,22 +1810,6 @@
         "node": ">=6.0"
       }
     },
-    "node_modules/chromium-bidi": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-16.0.1.tgz",
-      "integrity": "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA==",
-      "dev": true,
-      "dependencies": {
-        "mitt": "^3.0.1",
-        "zod": "^3.24.1"
-      },
-      "engines": {
-        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
-      },
-      "peerDependencies": {
-        "devtools-protocol": "*"
-      }
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -2154,61 +1929,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-      "dev": true,
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/cross-env": {
@@ -2406,12 +2126,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/devtools-protocol": {
-      "version": "0.0.1608973",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
-      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
-      "dev": true
-    },
     "node_modules/di": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
@@ -2548,15 +2262,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
     "node_modules/engine.io": {
       "version": "6.6.9",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
@@ -2633,24 +2338,6 @@
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
       "dev": true
-    },
-    "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
     },
     "node_modules/es-abstract": {
       "version": "1.23.3",
@@ -3242,15 +2929,6 @@
         "node": ">=0.8.x"
       }
     },
-    "node_modules/events-universal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-      "dev": true,
-      "dependencies": {
-        "bare-events": "^2.7.0"
-      }
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3261,12 +2939,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3947,12 +3619,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
     },
     "node_modules/is-async-function": {
       "version": "2.0.0",
@@ -4810,12 +4476,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
-    },
     "node_modules/loader-runner": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
@@ -5036,13 +4696,6 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
@@ -5647,24 +5300,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -5800,16 +5435,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -5821,16 +5446,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5840,68 +5455,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/puppeteer": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.0.3.tgz",
-      "integrity": "sha512-P2sLckgbW1P6o0p5d4V4SpoYFL9X8kJ3qC7rNKW1dz5WQ9t9wSCj0MnAZVZqax6BZHdBWQo2uLXM6F7O8cwmKg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@puppeteer/browsers": "3.0.3",
-        "chromium-bidi": "16.0.1",
-        "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1608973",
-        "puppeteer-core": "25.0.3",
-        "typed-query-selector": "^2.12.2"
-      },
-      "bin": {
-        "puppeteer": "lib/puppeteer/node/cli.js"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      }
-    },
-    "node_modules/puppeteer-core": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.0.3.tgz",
-      "integrity": "sha512-mNT7RWTAzgo9Q+TD8s1XzIOd6/7ZkbF40A0yNYanZOZZ7zSrFN1Am+EtL0nAMU5QWSSv6Dgi+3unRk0saeGcOg==",
-      "dev": true,
-      "dependencies": {
-        "@puppeteer/browsers": "3.0.3",
-        "chromium-bidi": "16.0.1",
-        "debug": "^4.4.3",
-        "devtools-protocol": "0.0.1608973",
-        "typed-query-selector": "^2.12.2",
-        "webdriver-bidi-protocol": "0.4.1",
-        "ws": "^8.20.0"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
     },
     "node_modules/qjobs": {
       "version": "1.2.0",
@@ -6588,17 +6141,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/streamx": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
-      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
-      "dev": true,
-      "dependencies": {
-        "events-universal": "^1.0.0",
-        "fast-fifo": "^1.3.2",
-        "text-decoder": "^1.1.0"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -6790,41 +6332,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
-      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^4.0.1",
-        "bare-path": "^3.0.0"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
-      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
-      "dev": true,
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "bare-fs": "^4.5.5",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
-    "node_modules/teex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "dev": true,
-      "dependencies": {
-        "streamx": "^2.12.5"
-      }
-    },
     "node_modules/terser": {
       "version": "5.42.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.42.0.tgz",
@@ -7007,15 +6514,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/text-decoder": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
-      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
-      "dev": true,
-      "dependencies": {
-        "b4a": "^1.6.4"
-      }
-    },
     "node_modules/tiny-svg": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-4.1.4.tgz",
@@ -7178,12 +6676,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/typed-query-selector": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
-      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
-      "dev": true
-    },
     "node_modules/ua-parser-js": {
       "version": "0.7.36",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.36.tgz",
@@ -7321,12 +6813,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/webdriver-bidi-protocol": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
-      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
-      "dev": true
     },
     "node_modules/webpack": {
       "version": "5.104.1",
@@ -7641,16 +7127,6 @@
       "integrity": "sha512-C40qyX4q79lECM6JyEVGjBqDhgPgGf19T3waOPUtlW+ZuWXl/tvuAsrBwHhJssWbAFJAGYdJ9urPF80EijUmLg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "karma-env-preprocessor": "^0.1.1",
         "karma-firefox-launcher": "^2.1.3",
         "karma-mocha": "^2.0.1",
-        "karma-tldr-reporter": "^0.0.1",
+        "karma-tldr-reporter": "^1.0.0",
         "karma-webpack": "^5.0.1",
         "min-dom": "^5.2.0",
         "mocha": "^11.0.0",
@@ -4401,9 +4401,9 @@
       }
     },
     "node_modules/karma-tldr-reporter": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/karma-tldr-reporter/-/karma-tldr-reporter-0.0.1.tgz",
-      "integrity": "sha512-UOKTRRS2oc6BoyiGUeP02oj0CAk46di+tb4atQXw2B+aOkRb4Hmki0pqb/rSTFckhKhc8LxvlwAgg5Go+CumUg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/karma-tldr-reporter/-/karma-tldr-reporter-1.0.0.tgz",
+      "integrity": "sha512-HGU8Qm7NqRh5TdLtJQABPPDIfGBOx1MtigDGjkj3R/1jBpH49Om/wo+vkb+I/6DvV89o/ah/xj8sGz3K9Y69EQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "mocha": "^11.0.0",
     "mocha-test-container-support": "^0.2.0",
     "npm-run-all2": "^9.0.0",
-    "puppeteer": "^25.0.0",
     "sinon": "^22.0.0",
     "sinon-chai": "^4.0.0",
     "webpack": "^5.101.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "karma-env-preprocessor": "^0.1.1",
     "karma-firefox-launcher": "^2.1.3",
     "karma-mocha": "^2.0.1",
-    "karma-tldr-reporter": "^0.0.1",
+    "karma-tldr-reporter": "^1.0.0",
     "karma-webpack": "^5.0.1",
     "min-dom": "^5.2.0",
     "mocha": "^11.0.0",

--- a/test/camunda-cloud/CreateZeebeBusinessRuleTaskBehaviorSpec.js
+++ b/test/camunda-cloud/CreateZeebeBusinessRuleTaskBehaviorSpec.js
@@ -1,0 +1,303 @@
+import { expect } from 'chai';
+
+import { bootstrapCamundaCloudModeler, inject } from 'test/TestHelper';
+
+import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
+import { find } from 'min-dash';
+
+import { getExtensionElementsList } from 'lib/util/ExtensionElementsUtil';
+
+
+import emptyProcessDiagramXML from './process-empty.bpmn';
+import businessRuleTasksXML from './process-businessRuleTask.bpmn';
+
+
+describe('camunda-cloud/features/modeling - CreateZeebeBusinessRuleTaskBehavior', function() {
+
+  describe('when a shape is created', function() {
+
+    beforeEach(bootstrapCamundaCloudModeler(emptyProcessDiagramXML));
+
+
+    it('should add zeebe:CalledDecision when creating bpmn:BusinessRuleTask', inject(function(
+        canvas,
+        modeling
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement();
+
+      // when
+      const newShape = modeling.createShape(
+        { type: 'bpmn:BusinessRuleTask' },
+        { x: 100, y: 100 },
+        rootElement
+      );
+
+      // then
+      const businessObject = getBusinessObject(newShape),
+            calledDecisionExtensions = getExtensionElementsList(businessObject, 'zeebe:CalledDecision');
+
+      expect(calledDecisionExtensions).to.exist;
+      expect(calledDecisionExtensions).to.have.lengthOf(1);
+    }));
+
+
+    it('should NOT add zeebe:CalledDecision if zeebe:CalledDecision already present', inject(function(
+        canvas,
+        bpmnFactory,
+        modeling
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement(),
+            bo = bpmnFactory.create('bpmn:BusinessRuleTask', {
+              extensionElements: bpmnFactory.create('bpmn:ExtensionElements', {
+                values: [ bpmnFactory.create('zeebe:CalledDecision', {
+                  decisionId: 'myDecision',
+                  resultVariable: 'result'
+                }) ],
+              }),
+            });
+
+      // when
+      const newShape = modeling.createShape(
+        { type: 'bpmn:BusinessRuleTask', businessObject: bo },
+        { x: 100, y: 100 },
+        rootElement
+      );
+
+      // then
+      const businessObject = getBusinessObject(newShape),
+            calledDecisionExtensions = getExtensionElementsList(businessObject, 'zeebe:CalledDecision');
+
+      expect(calledDecisionExtensions).to.exist;
+      expect(calledDecisionExtensions).to.have.lengthOf(1);
+    }));
+
+
+    it('should NOT add zeebe:CalledDecision if zeebe:TaskDefinition already present', inject(function(
+        canvas,
+        bpmnFactory,
+        modeling
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement(),
+            bo = bpmnFactory.create('bpmn:BusinessRuleTask', {
+              extensionElements: bpmnFactory.create('bpmn:ExtensionElements', {
+                values: [ bpmnFactory.create('zeebe:TaskDefinition', { type: 'my-job' }) ],
+              }),
+            });
+
+      // when
+      const newShape = modeling.createShape(
+        { type: 'bpmn:BusinessRuleTask', businessObject: bo },
+        { x: 100, y: 100 },
+        rootElement
+      );
+
+      // then
+      const businessObject = getBusinessObject(newShape),
+            calledDecisionExtensions = getExtensionElementsList(businessObject, 'zeebe:CalledDecision');
+
+      expect(calledDecisionExtensions).to.have.lengthOf(0);
+    }));
+
+
+    it('should NOT add zeebe:CalledDecision when creating bpmn:Task', inject(function(
+        canvas,
+        modeling
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement();
+
+      // when
+      const newShape = modeling.createShape(
+        { type: 'bpmn:Task' },
+        { x: 100, y: 100 },
+        rootElement
+      );
+
+      // then
+      const calledDecision = getCalledDecision(newShape);
+
+      expect(calledDecision).not.to.exist;
+    }));
+  });
+
+
+  describe('when a shape is pasted', function() {
+
+    beforeEach(bootstrapCamundaCloudModeler(businessRuleTasksXML));
+
+
+    it('should NOT add zeebe:CalledDecision to pasted bpmn:BusinessRuleTask with job worker', inject(function(
+        canvas,
+        copyPaste,
+        elementRegistry
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement();
+      const businessRuleTask = elementRegistry.get('BusinessRuleTask_2'); // has zeebe:TaskDefinition
+
+      // when
+      copyPaste.copy(businessRuleTask);
+
+      const elements = copyPaste.paste({
+        element: rootElement,
+        point: { x: 1000, y: 1000 },
+      });
+
+      // then
+      const pastedTask = find(elements, (element) =>
+        is(element, 'bpmn:BusinessRuleTask')
+      );
+
+      const calledDecisionExtensions = getExtensionElementsList(
+        getBusinessObject(pastedTask), 'zeebe:CalledDecision'
+      );
+
+      // job worker implementation should be preserved
+      expect(calledDecisionExtensions).to.have.lengthOf(0);
+    }));
+
+
+    it('should keep existing zeebe:CalledDecision on paste', inject(function(
+        canvas,
+        copyPaste,
+        elementRegistry
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement();
+      const businessRuleTask = elementRegistry.get('BusinessRuleTask_1'); // has zeebe:CalledDecision
+
+      // when
+      copyPaste.copy(businessRuleTask);
+
+      const elements = copyPaste.paste({
+        element: rootElement,
+        point: { x: 1000, y: 1000 },
+      });
+
+      // then
+      const pastedTask = find(elements, (element) =>
+        is(element, 'bpmn:BusinessRuleTask')
+      );
+
+      const calledDecisionExtensions = getExtensionElementsList(
+        getBusinessObject(pastedTask), 'zeebe:CalledDecision'
+      );
+
+      expect(calledDecisionExtensions).to.exist;
+      expect(calledDecisionExtensions).to.have.lengthOf(1);
+    }));
+  });
+
+
+  describe('when a shape is replaced', function() {
+
+    beforeEach(bootstrapCamundaCloudModeler(emptyProcessDiagramXML));
+
+
+    it('should add zeebe:CalledDecision when replacing bpmn:Task with bpmn:BusinessRuleTask', inject(function(
+        elementRegistry,
+        bpmnReplace,
+        canvas,
+        modeling
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement();
+      const task = modeling.createShape(
+        { type: 'bpmn:Task', id: 'simpleTask' },
+        { x: 100, y: 100 },
+        rootElement
+      );
+
+      // when
+      bpmnReplace.replaceElement(task, { type: 'bpmn:BusinessRuleTask' });
+
+      // then
+      const updatedTask = elementRegistry.get(task.id),
+            calledDecision = getCalledDecision(updatedTask);
+
+      expect(calledDecision).to.exist;
+    }));
+
+
+    it('should NOT add zeebe:CalledDecision when replacing bpmn:ServiceTask (with zeebe:TaskDefinition) with bpmn:BusinessRuleTask', inject(function(
+        elementRegistry,
+        bpmnFactory,
+        bpmnReplace,
+        canvas,
+        modeling
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement();
+
+      const bo = bpmnFactory.create('bpmn:ServiceTask', {
+        id: 'serviceTask',
+        extensionElements: bpmnFactory.create('bpmn:ExtensionElements', {
+          values: [ bpmnFactory.create('zeebe:TaskDefinition', { type: 'my-job' }) ],
+        }),
+      });
+
+      const serviceTask = modeling.createShape(
+        { type: 'bpmn:ServiceTask', businessObject: bo, id: 'serviceTask' },
+        { x: 100, y: 100 },
+        rootElement
+      );
+
+      // when
+      bpmnReplace.replaceElement(serviceTask, { type: 'bpmn:BusinessRuleTask' });
+
+      // then
+      const updatedTask = elementRegistry.get(serviceTask.id);
+      const calledDecisionExtensions = getExtensionElementsList(
+        getBusinessObject(updatedTask), 'zeebe:CalledDecision'
+      );
+
+      // existing job worker implementation must be preserved
+      expect(calledDecisionExtensions).to.have.lengthOf(0);
+    }));
+
+
+    it('should NOT add zeebe:CalledDecision when replacing bpmn:BusinessRuleTask with bpmn:ServiceTask', inject(function(
+        elementRegistry,
+        bpmnReplace,
+        canvas,
+        modeling
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement();
+      const task = modeling.createShape(
+        { type: 'bpmn:Task', id: 'simpleTask' },
+        { x: 100, y: 100 },
+        rootElement
+      );
+      bpmnReplace.replaceElement(task, { type: 'bpmn:ServiceTask' });
+
+      // then
+      const updatedTask = elementRegistry.get(task.id),
+            calledDecision = getCalledDecision(updatedTask);
+
+      expect(calledDecision).not.to.exist;
+    }));
+  });
+});
+
+
+// helpers //////////
+
+function getCalledDecision(element) {
+  const businessObject = getBusinessObject(element);
+  const calledDecisionElements = getExtensionElementsList(businessObject, 'zeebe:CalledDecision');
+
+  return calledDecisionElements[0] || null;
+}

--- a/test/camunda-cloud/CreateZeebeBusinessRuleTaskBehaviorSpec.js
+++ b/test/camunda-cloud/CreateZeebeBusinessRuleTaskBehaviorSpec.js
@@ -267,7 +267,7 @@ describe('camunda-cloud/features/modeling - CreateZeebeBusinessRuleTaskBehavior'
     }));
 
 
-    it('should NOT add zeebe:CalledDecision when replacing bpmn:BusinessRuleTask with bpmn:ServiceTask', inject(function(
+    it('should NOT carry over zeebe:CalledDecision when replacing bpmn:BusinessRuleTask with bpmn:ServiceTask', inject(function(
         elementRegistry,
         bpmnReplace,
         canvas,
@@ -276,15 +276,19 @@ describe('camunda-cloud/features/modeling - CreateZeebeBusinessRuleTaskBehavior'
 
       // given
       const rootElement = canvas.getRootElement();
-      const task = modeling.createShape(
-        { type: 'bpmn:Task', id: 'simpleTask' },
+
+      // Create a BusinessRuleTask — behavior adds zeebe:CalledDecision automatically
+      const businessRuleTask = modeling.createShape(
+        { type: 'bpmn:BusinessRuleTask', id: 'businessRuleTask' },
         { x: 100, y: 100 },
         rootElement
       );
-      bpmnReplace.replaceElement(task, { type: 'bpmn:ServiceTask' });
+
+      // when
+      bpmnReplace.replaceElement(businessRuleTask, { type: 'bpmn:ServiceTask' });
 
       // then
-      const updatedTask = elementRegistry.get(task.id),
+      const updatedTask = elementRegistry.get(businessRuleTask.id),
             calledDecision = getCalledDecision(updatedTask);
 
       expect(calledDecision).not.to.exist;

--- a/test/camunda-cloud/CreateZeebeScriptTaskBehaviorSpec.js
+++ b/test/camunda-cloud/CreateZeebeScriptTaskBehaviorSpec.js
@@ -269,7 +269,7 @@ describe('camunda-cloud/features/modeling - CreateZeebeScriptTaskBehavior', func
     }));
 
 
-    it('should NOT add zeebe:Script when replacing bpmn:ScriptTask with bpmn:ServiceTask', inject(function(
+    it('should NOT carry over zeebe:Script when replacing bpmn:ScriptTask with bpmn:ServiceTask', inject(function(
         elementRegistry,
         bpmnReplace,
         canvas,
@@ -278,15 +278,19 @@ describe('camunda-cloud/features/modeling - CreateZeebeScriptTaskBehavior', func
 
       // given
       const rootElement = canvas.getRootElement();
-      const task = modeling.createShape(
-        { type: 'bpmn:Task', id: 'simpleTask' },
+
+      // Create a ScriptTask — behavior adds zeebe:Script automatically
+      const scriptTask = modeling.createShape(
+        { type: 'bpmn:ScriptTask', id: 'scriptTask' },
         { x: 100, y: 100 },
         rootElement
       );
-      bpmnReplace.replaceElement(task, { type: 'bpmn:ServiceTask' });
+
+      // when
+      bpmnReplace.replaceElement(scriptTask, { type: 'bpmn:ServiceTask' });
 
       // then
-      const updatedTask = elementRegistry.get(task.id),
+      const updatedTask = elementRegistry.get(scriptTask.id),
             script = getScript(updatedTask);
 
       expect(script).not.to.exist;

--- a/test/camunda-cloud/CreateZeebeScriptTaskBehaviorSpec.js
+++ b/test/camunda-cloud/CreateZeebeScriptTaskBehaviorSpec.js
@@ -1,0 +1,305 @@
+import { expect } from 'chai';
+
+import { bootstrapCamundaCloudModeler, inject } from 'test/TestHelper';
+
+import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
+import { find } from 'min-dash';
+
+import { getExtensionElementsList } from 'lib/util/ExtensionElementsUtil';
+
+
+import emptyProcessDiagramXML from './process-empty.bpmn';
+import scriptTasksXML from './process-scriptTasks.bpmn';
+
+
+describe('camunda-cloud/features/modeling - CreateZeebeScriptTaskBehavior', function() {
+
+  describe('when a shape is created', function() {
+
+    beforeEach(bootstrapCamundaCloudModeler(emptyProcessDiagramXML));
+
+
+    it('should add zeebe:Script when creating bpmn:ScriptTask', inject(function(
+        canvas,
+        modeling
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement();
+
+      // when
+      const newShape = modeling.createShape(
+        { type: 'bpmn:ScriptTask' },
+        { x: 100, y: 100 },
+        rootElement
+      );
+
+      // then
+      const businessObject = getBusinessObject(newShape),
+            scriptExtensions = getExtensionElementsList(businessObject, 'zeebe:Script');
+
+      expect(scriptExtensions).to.exist;
+      expect(scriptExtensions).to.have.lengthOf(1);
+    }));
+
+
+    it('should NOT add zeebe:Script if zeebe:Script already present', inject(function(
+        canvas,
+        bpmnFactory,
+        modeling
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement(),
+            bo = bpmnFactory.create('bpmn:ScriptTask', {
+              extensionElements: bpmnFactory.create('bpmn:ExtensionElements', {
+                values: [ bpmnFactory.create('zeebe:Script', {
+                  expression: '= 1 + 1',
+                  resultVariable: 'result'
+                }) ],
+              }),
+            });
+
+      // when
+      const newShape = modeling.createShape(
+        { type: 'bpmn:ScriptTask', businessObject: bo },
+        { x: 100, y: 100 },
+        rootElement
+      );
+
+      // then
+      const businessObject = getBusinessObject(newShape),
+            scriptExtensions = getExtensionElementsList(businessObject, 'zeebe:Script');
+
+      expect(scriptExtensions).to.exist;
+      expect(scriptExtensions).to.have.lengthOf(1);
+    }));
+
+
+    it('should NOT add zeebe:Script if zeebe:TaskDefinition already present', inject(function(
+        canvas,
+        bpmnFactory,
+        modeling
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement(),
+            bo = bpmnFactory.create('bpmn:ScriptTask', {
+              extensionElements: bpmnFactory.create('bpmn:ExtensionElements', {
+                values: [ bpmnFactory.create('zeebe:TaskDefinition', { type: 'my-job' }) ],
+              }),
+            });
+
+      // when
+      const newShape = modeling.createShape(
+        { type: 'bpmn:ScriptTask', businessObject: bo },
+        { x: 100, y: 100 },
+        rootElement
+      );
+
+      // then
+      const businessObject = getBusinessObject(newShape),
+            scriptExtensions = getExtensionElementsList(businessObject, 'zeebe:Script');
+
+      expect(scriptExtensions).to.have.lengthOf(0);
+    }));
+
+
+    it('should NOT add zeebe:Script when creating bpmn:Task', inject(function(
+        canvas,
+        modeling
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement();
+
+      // when
+      const newShape = modeling.createShape(
+        { type: 'bpmn:Task' },
+        { x: 100, y: 100 },
+        rootElement
+      );
+
+      // then
+      const scriptExtension = getScript(newShape);
+
+      expect(scriptExtension).not.to.exist;
+    }));
+  });
+
+
+  describe('when a shape is pasted', function() {
+
+    beforeEach(bootstrapCamundaCloudModeler(scriptTasksXML));
+
+
+    it('should NOT add zeebe:Script to pasted bpmn:ScriptTask with job worker implementation', inject(function(
+        canvas,
+        copyPaste,
+        elementRegistry
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement();
+
+      // ScriptTask_jobWorker has zeebe:TaskDefinition (job worker) — paste it
+      const scriptTask = elementRegistry.get('ScriptTask_jobWorker');
+
+      // when
+      copyPaste.copy(scriptTask);
+
+      const elements = copyPaste.paste({
+        element: rootElement,
+        point: { x: 1000, y: 1000 },
+      });
+
+      // then
+      const pastedScriptTask = find(elements, (element) =>
+        is(element, 'bpmn:ScriptTask')
+      );
+
+      const scriptExtensions = getExtensionElementsList(
+        getBusinessObject(pastedScriptTask), 'zeebe:Script'
+      );
+
+      // job worker implementation should be preserved, no zeebe:Script added
+      expect(scriptExtensions).to.have.lengthOf(0);
+    }));
+
+
+    it('should keep existing zeebe:Script on paste', inject(function(
+        canvas,
+        copyPaste,
+        elementRegistry
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement();
+      const scriptTask = elementRegistry.get('ScriptTask_feelExpression');
+
+      // when
+      copyPaste.copy(scriptTask);
+
+      const elements = copyPaste.paste({
+        element: rootElement,
+        point: { x: 1000, y: 1000 },
+      });
+
+      // then
+      const pastedScriptTask = find(elements, (element) =>
+        is(element, 'bpmn:ScriptTask')
+      );
+
+      const scriptExtensions = getExtensionElementsList(
+        getBusinessObject(pastedScriptTask), 'zeebe:Script'
+      );
+
+      expect(scriptExtensions).to.exist;
+      expect(scriptExtensions).to.have.lengthOf(1);
+    }));
+  });
+
+
+  describe('when a shape is replaced', function() {
+
+    beforeEach(bootstrapCamundaCloudModeler(emptyProcessDiagramXML));
+
+
+    it('should add zeebe:Script when replacing bpmn:Task with bpmn:ScriptTask', inject(function(
+        elementRegistry,
+        bpmnReplace,
+        canvas,
+        modeling
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement();
+      const task = modeling.createShape(
+        { type: 'bpmn:Task', id: 'simpleTask' },
+        { x: 100, y: 100 },
+        rootElement
+      );
+
+      // when
+      bpmnReplace.replaceElement(task, { type: 'bpmn:ScriptTask' });
+
+      // then
+      const updatedTask = elementRegistry.get(task.id),
+            scriptExtension = getScript(updatedTask);
+
+      expect(scriptExtension).to.exist;
+    }));
+
+
+    it('should NOT add zeebe:Script when replacing bpmn:ServiceTask (with zeebe:TaskDefinition) with bpmn:ScriptTask', inject(function(
+        elementRegistry,
+        bpmnFactory,
+        bpmnReplace,
+        canvas,
+        modeling
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement();
+
+      const bo = bpmnFactory.create('bpmn:ServiceTask', {
+        id: 'serviceTask',
+        extensionElements: bpmnFactory.create('bpmn:ExtensionElements', {
+          values: [ bpmnFactory.create('zeebe:TaskDefinition', { type: 'my-job' }) ],
+        }),
+      });
+
+      const serviceTask = modeling.createShape(
+        { type: 'bpmn:ServiceTask', businessObject: bo, id: 'serviceTask' },
+        { x: 100, y: 100 },
+        rootElement
+      );
+
+      // when
+      bpmnReplace.replaceElement(serviceTask, { type: 'bpmn:ScriptTask' });
+
+      // then
+      const updatedTask = elementRegistry.get(serviceTask.id);
+      const scriptExtensions = getExtensionElementsList(
+        getBusinessObject(updatedTask), 'zeebe:Script'
+      );
+
+      // existing job worker implementation must be preserved
+      expect(scriptExtensions).to.have.lengthOf(0);
+    }));
+
+
+    it('should NOT add zeebe:Script when replacing bpmn:ScriptTask with bpmn:ServiceTask', inject(function(
+        elementRegistry,
+        bpmnReplace,
+        canvas,
+        modeling
+    ) {
+
+      // given
+      const rootElement = canvas.getRootElement();
+      const task = modeling.createShape(
+        { type: 'bpmn:Task', id: 'simpleTask' },
+        { x: 100, y: 100 },
+        rootElement
+      );
+      bpmnReplace.replaceElement(task, { type: 'bpmn:ServiceTask' });
+
+      // then
+      const updatedTask = elementRegistry.get(task.id),
+            script = getScript(updatedTask);
+
+      expect(script).not.to.exist;
+    }));
+  });
+});
+
+
+// helpers //////////
+
+function getScript(element) {
+  const businessObject = getBusinessObject(element);
+  const scriptElements = getExtensionElementsList(businessObject, 'zeebe:Script');
+
+  return scriptElements[0] || null;
+}

--- a/test/camunda-cloud/process-scriptTasks.bpmn
+++ b/test/camunda-cloud/process-scriptTasks.bpmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.20.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:scriptTask id="ScriptTask_jobWorker" name="ScriptTask_jobWorker">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="a" retries="3" />
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="ScriptTask_feelExpression" name="ScriptTask_feelExpression">
+      <bpmn:extensionElements>
+        <zeebe:script expression="= 1 + 1" resultVariable="result" />
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_jobWorker_di" bpmnElement="ScriptTask_jobWorker">
+        <dc:Bounds x="160" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_feelExpression_di" bpmnElement="ScriptTask_feelExpression">
+        <dc:Bounds x="350" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Summary

When creating a new `bpmn:ScriptTask` or `bpmn:BusinessRuleTask`, the properties panel currently shows `<none>` as the implementation, requiring an extra manual step before the task is useful. This aligns them with `bpmn:UserTask`, which already defaults to "Camunda user task" (`zeebe:UserTask`) on creation.

- Adds `CreateZeebeScriptTaskBehavior`: adds `zeebe:Script` extension element when a `bpmn:ScriptTask` is created or replaced, defaulting to the "FEEL expression" implementation
- Adds `CreateZeebeBusinessRuleTaskBehavior`: adds `zeebe:CalledDecision` extension element when a `bpmn:BusinessRuleTask` is created or replaced, defaulting to the "DMN decision" implementation
- Both behaviors skip if any implementation (`zeebe:Script`/`zeebe:CalledDecision` or `zeebe:TaskDefinition`) is already set, preserving existing configuration when replacing another task type

Related to camunda/camunda-modeler#6015.

## Test plan

- [ ] Creating a new script task immediately shows "FEEL expression" selected in the properties panel
- [ ] Creating a new business rule task immediately shows "DMN decision" selected in the properties panel
- [ ] Replacing a job worker service task with a script/BRT preserves the job worker implementation
- [ ] Pasting an existing element preserves its implementation unchanged
- [ ] All new unit tests pass