### PR TITLE
test(camunda-cloud): verify Call Activity Business ID morph cleanup

### DIFF
--- a/test/camunda-cloud/CallActivityBusinessIdSpec.js
+++ b/test/camunda-cloud/CallActivityBusinessIdSpec.js
@@ -1,0 +1,85 @@
+import { expect } from 'chai';
+
+import {
+  bootstrapCamundaCloudModeler,
+  inject
+} from 'test/TestHelper';
+
+import { getCalledElement } from 'lib/camunda-cloud/util/CalledElementUtil';
+
+import diagramXML from './process-call-activity-business-id.bpmn';
+
+
+describe('camunda-cloud/features/modeling - Call Activity Business ID', function() {
+
+  beforeEach(bootstrapCamundaCloudModeler(diagramXML));
+
+  [
+    'bpmn:Task',
+    'bpmn:UserTask',
+    'bpmn:SubProcess'
+  ].forEach(function(targetType) {
+
+    describe(`morph Call Activity with Business ID to ${targetType}`, function() {
+
+      it('should remove Business ID', inject(function(bpmnReplace, elementRegistry) {
+
+        // given
+        const callActivity = elementRegistry.get('CallActivityWithBusinessId');
+
+        // assume
+        expect(getCalledElement(callActivity).get('businessId')).to.equal('=order.customerId');
+
+        // when
+        bpmnReplace.replaceElement(callActivity, { type: targetType });
+
+        // then
+        const element = elementRegistry.get('CallActivityWithBusinessId');
+
+        expect(getCalledElement(element)).not.to.exist;
+      }));
+
+
+      it('should remove empty (null) Business ID', inject(function(bpmnReplace, elementRegistry) {
+
+        // given
+        const callActivity = elementRegistry.get('CallActivityWithEmptyBusinessId');
+
+        // assume
+        expect(getCalledElement(callActivity).get('businessId')).to.equal('');
+
+        // when
+        bpmnReplace.replaceElement(callActivity, { type: targetType });
+
+        // then
+        const element = elementRegistry.get('CallActivityWithEmptyBusinessId');
+
+        expect(getCalledElement(element)).not.to.exist;
+      }));
+
+    });
+
+  });
+
+
+  describe('undo', function() {
+
+    it('should restore Business ID', inject(function(bpmnReplace, elementRegistry, commandStack) {
+
+      // given
+      const callActivity = elementRegistry.get('CallActivityWithBusinessId');
+
+      bpmnReplace.replaceElement(callActivity, { type: 'bpmn:Task' });
+
+      // when
+      commandStack.undo();
+
+      // then
+      const element = elementRegistry.get('CallActivityWithBusinessId');
+
+      expect(getCalledElement(element).get('businessId')).to.equal('=order.customerId');
+    }));
+
+  });
+
+});

--- a/test/camunda-cloud/process-call-activity-business-id.bpmn
+++ b/test/camunda-cloud/process-call-activity-business-id.bpmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:callActivity id="CallActivityWithBusinessId">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="foo" businessId="=order.customerId" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="CallActivityWithEmptyBusinessId">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="foo" businessId="" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="CallActivityWithBusinessId_di" bpmnElement="CallActivityWithBusinessId">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivityWithEmptyBusinessId_di" bpmnElement="CallActivityWithEmptyBusinessId">
+        <dc:Bounds x="160" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
This PR adds only a regression test.

### Proposed Changes

🤖 

The Business ID lives on zeebe:CalledElement, which is `allowedIn` bpmn:CallActivity only. Morphing away from a Call Activity therefore drops the extension element (and the Business ID) through core moddle copy - no dedicated behavior is required, consistent with bindingType having no downgrade cleanup either.

Adds a regression test covering morph to Task/UserTask/SubProcess for both a value and an empty (null) override.

Related to https://github.com/camunda/camunda-modeler/issues/5912

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
